### PR TITLE
support mac M1

### DIFF
--- a/tools/gohub/cmd/tools/install/install.go
+++ b/tools/gohub/cmd/tools/install/install.go
@@ -149,6 +149,8 @@ func runCommand(wd string, exe string, params ...string) {
 func downloadProtoc(dir string, verbose bool) string {
 	var url string
 	switch {
+	case runtime.GOOS == "darwin" && runtime.GOARCH == "arm64":
+		url = "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-osx-x86_64.zip"
 	case runtime.GOOS == "darwin" && runtime.GOARCH == "amd64":
 		url = "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-osx-x86_64.zip"
 	case runtime.GOOS == "linux" && runtime.GOARCH == "amd64":


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug

#### What this PR does / why we need it:
under mac M1, runtime.GOARCH value is arm64. because currently there is no real protobuf release for darwin-arm64 and the darwin-x64 binary can run on mac M1 with the rosetta compatibility, so here just use the same release.

#### Specified Reivewers:
/assgin @liuhaoyang  @recallsong 

