### PR TITLE
support partial config unmarshal

### DIFF
--- a/base/servicehub/provider_context.go
+++ b/base/servicehub/provider_context.go
@@ -75,6 +75,25 @@ func (c *providerContext) BindConfig(flags *pflag.FlagSet) (err error) {
 	return nil
 }
 
+func BindConfig(src, dst interface{}) error {
+	if src == nil {
+		return nil
+	}
+	err := unmarshal.BindDefault(dst)
+	if err != nil {
+		return err
+	}
+	err = config.ConvertData(src, dst, "file")
+	if err != nil {
+		return err
+	}
+	err = unmarshal.BindEnv(dst)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (c *providerContext) Init() (err error) {
 	if reflect.ValueOf(c.provider).Kind() == reflect.Ptr && c.structType != nil {
 		value, typ := c.structValue, c.structType

--- a/base/servicehub/provider_context.go
+++ b/base/servicehub/provider_context.go
@@ -47,25 +47,9 @@ func (c *providerContext) BindConfig(flags *pflag.FlagSet) (err error) {
 	if creator, ok := c.define.(ConfigCreator); ok {
 		cfg := creator.Config()
 		if cfg != nil {
-			err = unmarshal.BindDefault(cfg)
+			err := BindConfig(c.cfg, cfg, flags)
 			if err != nil {
 				return err
-			}
-			if c.cfg != nil {
-				err = config.ConvertData(c.cfg, cfg, "file")
-				if err != nil {
-					return err
-				}
-			}
-			err = unmarshal.BindEnv(cfg)
-			if err != nil {
-				return err
-			}
-			if flags != nil {
-				err = unmarshalflag.BindFlag(flags, cfg)
-				if err != nil {
-					return err
-				}
 			}
 			c.cfg = cfg
 			return nil
@@ -75,21 +59,26 @@ func (c *providerContext) BindConfig(flags *pflag.FlagSet) (err error) {
 	return nil
 }
 
-func BindConfig(src, dst interface{}) error {
-	if src == nil {
-		return nil
-	}
+func BindConfig(src, dst interface{}, flags *pflag.FlagSet) error {
 	err := unmarshal.BindDefault(dst)
 	if err != nil {
 		return err
 	}
-	err = config.ConvertData(src, dst, "file")
-	if err != nil {
-		return err
+	if src != nil {
+		err = config.ConvertData(src, dst, "file")
+		if err != nil {
+			return err
+		}
 	}
 	err = unmarshal.BindEnv(dst)
 	if err != nil {
 		return err
+	}
+	if flags != nil {
+		err = unmarshalflag.BindFlag(flags, dst)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/base/servicehub/provider_context_test.go
+++ b/base/servicehub/provider_context_test.go
@@ -130,8 +130,9 @@ func TestBindConfig(t *testing.T) {
 	}
 
 	type args struct {
-		src interface{}
-		dst interface{}
+		src   interface{}
+		dst   interface{}
+		flags *pflag.FlagSet
 	}
 	tests := []struct {
 		name string
@@ -175,7 +176,7 @@ func TestBindConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := BindConfig(tt.args.src, tt.args.dst); err != nil {
+			if err := BindConfig(tt.args.src, tt.args.dst, tt.args.flags); err != nil {
 				t.Errorf("BindConfig() error = %v", err)
 			}
 			if !reflect.DeepEqual(tt.args.dst, tt.want) {


### PR DESCRIPTION
#### What type of this PR

/kind feature

#### What this PR does / why we need it:
support partial config Bind, so we can unmarshal dynamic to certain config struct.

example:
```go
type config struct {
	SignAuth struct {
		SKProvider string      `file:"sk_provider"`
		Config     interface{} `file:"config"`
	} `file:"sign_auth"`
}

type staticSKProviderConfig struct {
	SecretKey string `file:"secretKey"`
}
```
different `SKProvider` have different config struct, so we can unmarshal `Config` to different config struct 

#### Which issue(s) this PR fixes:
Fixes #

#### Specified Reivewers:
/assgin @recallsong @liuhaoyang 

