### PR TITLE
fix accept

### DIFF
--- a/pkg/transport/http/encoding/encoding.go
+++ b/pkg/transport/http/encoding/encoding.go
@@ -50,6 +50,9 @@ func DecodeRequest(r *http.Request, out interface{}) error {
 	}
 	switch mtype {
 	case "application/protobuf", "application/x-protobuf":
+		if r.ContentLength <= 0 {
+			return nil
+		}
 		if msg, ok := out.(proto.Message); ok {
 			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {
@@ -61,6 +64,9 @@ func DecodeRequest(r *http.Request, out interface{}) error {
 			return proto.Unmarshal(body, msg)
 		}
 	case "application/json":
+		if r.ContentLength <= 0 {
+			return nil
+		}
 		if um, ok := out.(json.Unmarshaler); ok {
 			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {
@@ -86,9 +92,6 @@ func DecodeRequest(r *http.Request, out interface{}) error {
 			}
 			return un.UnmarshalURLValues("", r.Form)
 		}
-	}
-	if r.ContentLength <= 0 {
-		return nil
 	}
 	return notSupportMediaTypeErr{text: fmt.Sprintf("not support media type: %s", mtype)}
 }


### PR DESCRIPTION
#### What type of this PR

/kind bug

#### What this PR does / why we need it:
https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1

If no Accept header field is present, then it is assumed that the client accepts all media types. If an Accept header field is present, and if the server cannot send a response which is acceptable according to the combined Accept field value, then the server SHOULD send a 406 (not acceptable) response.


#### Specified Reivewers:
@liuhaoyang 

