### PR TITLE
provider mysqlxorm support session for transparent transaction and init-ping

### DIFF
--- a/providers/mysqlxorm/examples/examples.yaml
+++ b/providers/mysqlxorm/examples/examples.yaml
@@ -4,5 +4,7 @@ mysql-xorm:
     username: "${MYSQL_USERNAME:root}"
     password: "${MYSQL_PASSWORD:123456}"
     database: "${MYSQL_DATABASE:test}"
+    ping_when_init: true
+    ping_timeout_sec: 5
 
 example:

--- a/providers/mysqlxorm/session.go
+++ b/providers/mysqlxorm/session.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mysqlxorm
+
+import (
+	"github.com/xormplus/xorm"
+)
+
+type (
+	session struct {
+		*xorm.Session
+		needAutoClose bool
+	}
+	SessionOption func(s *session)
+)
+
+func WithSession(passedInSession *session) SessionOption {
+	return func(s *session) {
+		s.Session = passedInSession.Session
+	}
+}
+
+func (p *provider) NewSession(opts ...SessionOption) *session {
+	tx := &session{}
+
+	for _, opt := range opts {
+		opt(tx)
+	}
+
+	// set default session
+	if tx.Session == nil {
+		tx.Session = p.db.NewSession()
+		tx.needAutoClose = true
+	}
+
+	return tx
+}
+
+func (tx *session) Close() {
+	if tx.needAutoClose {
+		tx.Session.Close()
+	}
+	return
+}

--- a/providers/mysqlxorm/xorm.go
+++ b/providers/mysqlxorm/xorm.go
@@ -31,6 +31,7 @@ import (
 // Interface .
 type Interface interface {
 	DB() *xorm.Engine
+	NewSession(ops ...SessionOption) *session
 }
 
 var (


### PR DESCRIPTION
#### What type of this PR

/kind feature

#### What this PR does / why we need it:

- support ping when init to check database advanced
- migrated feature: support session for transparent transaction delivery, see example for usage, which is already used in pipeline