### PR TITLE
fix typo in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,5 +14,5 @@ Add one of the following kinds:
 Fixes #
 
 #### Specified Reivewers:
-/assgin @your-reviewer
+/assign @your-reviewer
 


### PR DESCRIPTION
#### What type of this PR

/kind polish

#### What this PR does / why we need it:

Fix typo of `assign`. So erda-bot can assign pr reviewers correctly.

#### Specified Reivewers:
/assign @recallsong 

