### PR TITLE
component-protocol: calculateDefaultRenderOrderByHierarchy if missing `__DefaultRendering__`

### DIFF
--- a/providers/component-protocol/protocol/render_test.go
+++ b/providers/component-protocol/protocol/render_test.go
@@ -16,6 +16,11 @@ package protocol
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+
+	"github.com/erda-project/erda-infra/providers/component-protocol/cptype"
 )
 
 func Test_getCompNameAndInstanceName(t *testing.T) {
@@ -57,5 +62,53 @@ func Test_getCompNameAndInstanceName(t *testing.T) {
 				t.Errorf("getCompNameAndInstanceName() gotInstanceName = %v, want %v", gotInstanceName, tt.wantInstanceName)
 			}
 		})
+	}
+}
+
+func Test_calculateDefaultRenderOrderByHierarchy(t *testing.T) {
+	py := `
+hierarchy:
+  root: page
+  structure:
+    page:
+      - filter
+      - overview_group
+      - blocks
+    overview_group:
+      - quality_chart
+      - blocks
+    blocks:
+      - mt_block
+      - at_block
+    mt_block:
+      - mt_block_header
+      - mt_block_detail
+    mt_block_header:
+      right: mt_block_header_filter
+      left: mt_block_header_title
+`
+	var p cptype.ComponentProtocol
+	assert.NoError(t, yaml.Unmarshal([]byte(py), &p))
+	orders, err := calculateDefaultRenderOrderByHierarchy(&p)
+	assert.NoError(t, err)
+	expected := []string{"page", "filter", "overview_group", "quality_chart", "blocks", "mt_block",
+		"mt_block_header", "mt_block_header_title", "mt_block_header_filter",
+		"mt_block_detail", "at_block"}
+	for i := range expected {
+		assert.True(t,true, expected[i] == orders[i])
+	}
+}
+
+func Test_recursiveWalkCompOrder(t *testing.T) {
+	// recursive walk from root
+	var result []string
+	allCompSubMap := make(map[string][]string)
+	allCompSubMap["page"] = []string{"title", "overview", "filter"}
+	allCompSubMap["overview"] = []string{"quality_chart", "blocks"}
+	err := recursiveWalkCompOrder("page", &result, allCompSubMap)
+	assert.NoError(t, err)
+	expected := []string{"page", "title", "overview", "quality_chart", "blocks", "filter"}
+	for i := range expected {
+		assert.True(t,true, expected[i] == result[i])
 	}
 }

--- a/providers/component-protocol/protocol/scenario.go
+++ b/providers/component-protocol/protocol/scenario.go
@@ -16,7 +16,6 @@ package protocol
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/erda-project/erda-infra/providers/component-protocol/cptype"
 )
@@ -47,10 +46,7 @@ func getScenarioRenders(scenario string) (*ScenarioRender, error) {
 		return nil, fmt.Errorf("failed to get scenario renders, default protocol not exist, scenario: %s", scenario)
 	}
 	for compName, comp := range p.Components {
-		ss := strings.SplitN(compName, "@", 2)
-		if len(ss) == 2 {
-			compName = ss[0]
-		}
+		compName, _ = getCompNameAndInstanceName(compName)
 		// skip if scenario-level component render exist
 		_, renderExist := (*renders)[compName]
 		if renderExist {


### PR DESCRIPTION
#### What type of this PR

/kind feature

#### What this PR does / why we need it:

component-protocol: calculate default render order by Hierarchy if missing `__DefaultRendering__`.


#### Specified Reivewers:
/assign @Effet 

