### PR TITLE
fix: cp default rendering recursive get sub comps

### DIFF
--- a/providers/component-protocol/protocol/component.go
+++ b/providers/component-protocol/protocol/component.go
@@ -133,7 +133,7 @@ func protoCompStateRending(ctx context.Context, p *cptype.ComponentProtocol, r c
 			// get bound key value
 			stateFromValue, err = getProtoCompStateValue(ctx, p, stateFrom, stateFromKey)
 			if err != nil {
-				logrus.Errorf("failed to get component state value, component: %s, key: %s", stateFrom, stateFromKey)
+				logrus.Errorf("failed to get component state value, toComponent: %s, fromComponent: %s, key: %s", r.Name, stateFrom, stateFromKey)
 				return err
 			}
 		}

--- a/providers/component-protocol/protocol/render_test.go
+++ b/providers/component-protocol/protocol/render_test.go
@@ -76,6 +76,7 @@ hierarchy:
       - overview_group
       - blocks
       - mt_plan_chart_group
+      - leftHead
     overview_group:
       - quality_chart
       - blocks
@@ -93,6 +94,13 @@ hierarchy:
         - mt_plan_chart2
         - mt_plan_chart
       extraContent: mt_plan_chart_filter
+    leftHead:
+      right:
+        - leftHeadAddSceneSet
+        - moreOperation
+      left: leftHeadTitle
+      tabBarExtraContent:
+        - tabSceneSetExecuteButton
 `
 	var p cptype.ComponentProtocol
 	assert.NoError(t, yaml.Unmarshal([]byte(py), &p))
@@ -101,7 +109,9 @@ hierarchy:
 	expected := []string{"page", "filter", "overview_group", "quality_chart", "blocks", "mt_block",
 		"mt_block_header", "mt_block_header_title", "mt_block_header_filter",
 		"mt_block_detail", "at_block",
-		"mt_plan_chart_group", "mt_plan_chart_filter", "mt_plan_chart2", "mt_plan_chart"}
+		"mt_plan_chart_group", "mt_plan_chart_filter", "mt_plan_chart2", "mt_plan_chart",
+		"leftHead", "leftHeadTitle", "leftHeadAddSceneSet", "moreOperation", "tabSceneSetExecuteButton",
+	}
 	assert.Equal(t, expected, orders)
 }
 


### PR DESCRIPTION
#### What type of this PR

/kind bug

#### What this PR does / why we need it:

adapt for structure `right` have list sub components.

```yaml
hierarchy:
  ......
  structure:
    leftHead:
      right:
        - leftHeadAddSceneSet
        - moreOperation
      left: leftHeadTitle
```


#### Which issue(s) this PR fixes:
Fixes #

#### Specified Reivewers:
/assign @Effet 

