### PR TITLE
cp: operation add skipRender option

### DIFF
--- a/providers/component-protocol/cptype/operation.go
+++ b/providers/component-protocol/cptype/operation.go
@@ -28,6 +28,7 @@ type Operation struct {
 	Confirm     string `json:"confirm,omitempty"`
 	Disabled    bool   `json:"disabled,omitempty"`
 	DisabledTip string `json:"disabledTip,omitempty"`
+	SkipRender  bool   `json:"skipRender,omitempty"` // skipRender means this op is just a frontend op, won't invoke backend to render.
 	Async       bool   `json:"async,omitempty"`
 
 	// ServerData generated at server-side.

--- a/providers/component-protocol/utils/cputil/operation_builder.go
+++ b/providers/component-protocol/utils/cputil/operation_builder.go
@@ -50,6 +50,12 @@ func (b *OperationBuilder) WithDisable(disable bool, disableTip string) *Operati
 	return b
 }
 
+// WithSkipRender .
+func (b *OperationBuilder) WithSkipRender(skipRender bool) *OperationBuilder {
+	b.Operation.SkipRender = skipRender
+	return b
+}
+
 // WithAsync .
 func (b *OperationBuilder) WithAsync(async bool) *OperationBuilder {
 	b.Operation.Async = async


### PR DESCRIPTION
#### What type of this PR

/kind feature

#### What this PR does / why we need it:

cp: operation add skipRender option, means this op is just a frontend op, won't invoke backend to render

#### Specified Reivewers:
/assign @Effet @shuofan 

