### PR TITLE
fix: cp opServerData do not wrap `extra` key

### DIFF
--- a/providers/component-protocol/cptype/operation.go
+++ b/providers/component-protocol/cptype/operation.go
@@ -44,6 +44,4 @@ type OpClientData struct {
 }
 
 // OpServerData .
-type OpServerData struct {
-	Extra ExtraMap `json:"extra,omitempty"`
-}
+type OpServerData ExtraMap

--- a/providers/component-protocol/utils/cputil/operation_builder.go
+++ b/providers/component-protocol/utils/cputil/operation_builder.go
@@ -68,39 +68,10 @@ func (b *OperationBuilder) WithAsync(async bool) *OperationBuilder {
 	return b
 }
 
-// AppendExtraKV .
-func (b *OperationBuilder) AppendExtraKV(k string, v interface{}) *OperationBuilder {
-	if b.Operation.ServerData == nil {
-		b.Operation.ServerData = &cptype.OpServerData{}
-	}
-	if b.Operation.ServerData.Extra == nil {
-		b.Operation.ServerData.Extra = make(cptype.ExtraMap)
-	}
-	b.Operation.ServerData.Extra[k] = v
-	return b
-}
-
-// AppendExtraKVs .
-func (b *OperationBuilder) AppendExtraKVs(kvs map[string]interface{}) *OperationBuilder {
-	for k, v := range kvs {
-		b.AppendExtraKV(k, v)
-	}
-	return b
-}
-
 // WithServerDataPtr .
 func (b *OperationBuilder) WithServerDataPtr(inputPtr interface{}) *OperationBuilder {
-	var serverData cptype.ExtraMap
+	var serverData cptype.OpServerData
 	MustObjJSONTransfer(inputPtr, &serverData)
-	b.Operation.ServerData = &cptype.OpServerData{Extra: serverData}
-	return b
-}
-
-// WithExtraKVs .
-func (b *OperationBuilder) WithExtraKVs(kvs map[string]interface{}) *OperationBuilder {
-	if b.Operation.ServerData == nil {
-		b.Operation.ServerData = &cptype.OpServerData{}
-	}
-	b.Operation.ServerData.Extra = kvs
+	b.Operation.ServerData = &serverData
 	return b
 }


### PR DESCRIPTION
#### What type of this PR

/kind bug

#### What this PR does / why we need it:

fix: cp opServerData do not wrap `extra` key.

before:
![image](https://user-images.githubusercontent.com/13919034/147430139-13b36858-9406-4678-9c39-c294ccf06c38.png)

now: 
![image](https://user-images.githubusercontent.com/13919034/147430119-661933d2-cf7d-4db5-b8a4-76b76a425b79.png)


#### Specified Reivewers:
/assign @Effet 

