### PR TITLE
feat: cp: support component-level continue render

### DIFF
--- a/providers/component-protocol/cptype/protocol.go
+++ b/providers/component-protocol/cptype/protocol.go
@@ -86,9 +86,17 @@ type ComponentOptions struct {
 	Visible     bool `json:"visible,omitempty" yaml:"visible,omitempty"`
 	AsyncAtInit bool `json:"asyncAtInit,omitempty" yaml:"asyncAtInit,omitempty"`
 
+	// enable continueRender if not nil
+	ContinueRender *ContinueRender `json:"continueRender,omitempty" yaml:"continueRender,omitempty"`
+
 	// extra related
 	FlatExtra            bool `json:"flatExtra,omitempty" yaml:"flatExtra,omitempty"`
 	RemoveExtraAfterFlat bool `json:"removeExtraAfterFlat,omitempty" yaml:"removeExtraAfterFlat,omitempty"`
+}
+
+// ContinueRender .
+type ContinueRender struct {
+	OpKey string `json:"opKey,omitempty"`
 }
 
 // RendingItem .
@@ -153,4 +161,7 @@ type ComponentProtocolDebugOptions struct {
 type ProtocolOptions struct {
 	// SyncIntervalSecond can be float64, such as 10, 1, 0.5 .
 	SyncIntervalSecond float64 `json:"syncIntervalSecond" yaml:"syncIntervalSecond"`
+
+	// ParallelContinueRenders contains all component-level continue-render.
+	ParallelContinueRenders map[string]ContinueRender `json:"continueRenders,omitempty" yaml:"continueRenders,omitempty"`
 }

--- a/providers/component-protocol/cptype/protocol.go
+++ b/providers/component-protocol/cptype/protocol.go
@@ -163,5 +163,5 @@ type ProtocolOptions struct {
 	SyncIntervalSecond float64 `json:"syncIntervalSecond" yaml:"syncIntervalSecond"`
 
 	// ParallelContinueRenders contains all component-level continue-render.
-	ParallelContinueRenders map[string]ContinueRender `json:"continueRenders,omitempty" yaml:"continueRenders,omitempty"`
+	ParallelContinueRenders map[string]ContinueRender `json:"parallelContinueRenders,omitempty" yaml:"parallelContinueRenders,omitempty"`
 }

--- a/providers/component-protocol/protocol/posthook/continue_render.go
+++ b/providers/component-protocol/protocol/posthook/continue_render.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package posthook
+
+import (
+	"github.com/erda-project/erda-infra/providers/component-protocol/cptype"
+)
+
+// HandleContinueRender set continueRender to globalOptions from rendering components.
+func HandleContinueRender(renderingItems []cptype.RendingItem, req *cptype.ComponentProtocol) {
+	result := make(map[string]cptype.ContinueRender)
+	for _, comp := range renderingItems {
+		compOptions := req.Components[comp.Name].Options
+		if compOptions == nil || compOptions.ContinueRender == nil || compOptions.ContinueRender.OpKey == "" {
+			continue
+		}
+		result[comp.Name] = *compOptions.ContinueRender
+	}
+	if req.Options == nil {
+		req.Options = &cptype.ProtocolOptions{}
+	}
+	req.Options.ParallelContinueRenders = result
+}

--- a/providers/component-protocol/protocol/posthook/continue_render_test.go
+++ b/providers/component-protocol/protocol/posthook/continue_render_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package posthook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda-infra/providers/component-protocol/cptype"
+)
+
+func TestHandleContinueRender(t *testing.T) {
+	renderingItems := []cptype.RendingItem{{Name: "page"}, {Name: "list"}}
+	p := cptype.ComponentProtocol{
+		Components: map[string]*cptype.Component{
+			"page": {
+				Options: &cptype.ComponentOptions{
+					ContinueRender: &cptype.ContinueRender{
+						OpKey: "loadPageMore",
+					},
+				},
+			},
+			"list": {
+				Options: &cptype.ComponentOptions{
+					ContinueRender: &cptype.ContinueRender{
+						OpKey: "loadListDetail",
+					},
+				},
+			},
+		},
+		Options: nil,
+	}
+	HandleContinueRender(renderingItems, &p)
+	assert.NotNil(t, p.Options)
+	assert.True(t, len(p.Options.ParallelContinueRenders) == 2)
+	assert.True(t, p.Options.ParallelContinueRenders["page"].OpKey == "loadPageMore")
+	assert.True(t, p.Options.ParallelContinueRenders["list"].OpKey == "loadListDetail")
+}

--- a/providers/component-protocol/protocol/posthook/only_return_rendering.go
+++ b/providers/component-protocol/protocol/posthook/only_return_rendering.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package posthook
+
+import (
+	"github.com/erda-project/erda-infra/providers/component-protocol/cptype"
+)
+
+// OnlyReturnRenderingComps only return rendering components.
+func OnlyReturnRenderingComps(renderingItems []cptype.RendingItem, req *cptype.ComponentProtocol) {
+	// init new components map
+	onlyReturnComps := make(map[string]*cptype.Component, len(req.Components))
+	// construct map for easy use
+	renderingItemByName := map[string]struct{}{}
+	for _, item := range renderingItems {
+		renderingItemByName[item.Name] = struct{}{}
+	}
+	// only return rendering components
+	for name := range req.Components {
+		if _, ok := renderingItemByName[name]; ok {
+			onlyReturnComps[name] = req.Components[name]
+		}
+	}
+	req.Components = onlyReturnComps
+}

--- a/providers/component-protocol/protocol/posthook/only_return_rendering_test.go
+++ b/providers/component-protocol/protocol/posthook/only_return_rendering_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package posthook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda-infra/providers/component-protocol/cptype"
+)
+
+func TestOnlyReturnRenderingComps(t *testing.T) {
+	renderingItems := []cptype.RendingItem{{Name: "page"}, {Name: "list"}}
+	p := cptype.ComponentProtocol{
+		Components: map[string]*cptype.Component{
+			"page":  {},
+			"list":  {},
+			"table": {},
+		},
+	}
+	assert.True(t, len(p.Components) == 3)
+	OnlyReturnRenderingComps(renderingItems, &p)
+	assert.True(t, len(p.Components) == 2)
+}

--- a/providers/component-protocol/protocol/render.go
+++ b/providers/component-protocol/protocol/render.go
@@ -135,6 +135,9 @@ func RunScenarioRender(ctx context.Context, req *cptype.ComponentProtocolRequest
 			return err
 		}
 	}
+
+	handleContinueRender(compRending, req.Protocol)
+
 	return nil
 }
 
@@ -371,4 +374,20 @@ func renderOneComp(ctx context.Context, req *cptype.ComponentProtocolRequest, sr
 	elapsed := time.Since(start)
 	logrus.Infof("[component render time cost] scenario: %s, component: %s, cost: %s", req.Scenario.ScenarioKey, v.Name, elapsed)
 	return nil
+}
+
+// handleContinueRender set continueRender to globalOptions from rendering components.
+func handleContinueRender(renderingItems []cptype.RendingItem, req *cptype.ComponentProtocol) {
+	result := make(map[string]cptype.ContinueRender)
+	for _, comp := range renderingItems {
+		compOptions := req.Components[comp.Name].Options
+		if compOptions == nil || compOptions.ContinueRender == nil || compOptions.ContinueRender.OpKey == "" {
+			continue
+		}
+		result[comp.Name] = *compOptions.ContinueRender
+	}
+	if req.Options == nil {
+		req.Options = &cptype.ProtocolOptions{}
+	}
+	req.Options.ParallelContinueRenders = result
 }

--- a/providers/component-protocol/protocol/render.go
+++ b/providers/component-protocol/protocol/render.go
@@ -138,6 +138,8 @@ func RunScenarioRender(ctx context.Context, req *cptype.ComponentProtocolRequest
 
 	handleContinueRender(compRending, req.Protocol)
 
+	onlyReturnRenderingComps(compRending, req.Protocol)
+
 	return nil
 }
 
@@ -390,4 +392,17 @@ func handleContinueRender(renderingItems []cptype.RendingItem, req *cptype.Compo
 		req.Options = &cptype.ProtocolOptions{}
 	}
 	req.Options.ParallelContinueRenders = result
+}
+
+// onlyReturnRenderingComps only return rendering components.
+func onlyReturnRenderingComps(renderingItems []cptype.RendingItem, req *cptype.ComponentProtocol) {
+	renderingItemByName := map[string]struct{}{}
+	for _, item := range renderingItems {
+		renderingItemByName[item.Name] = struct{}{}
+	}
+	for name := range req.Components {
+		if _, ok := renderingItemByName[name]; !ok {
+			req.Components[name] = nil
+		}
+	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

cp: 

- support component-level continue render
- render only return rendering components

#### Which issue(s) this PR fixes:

[Erda Related Issue](https://erda.cloud/erda/dop/projects/387/issues/all?id=273374&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDA2LDQ0MDddfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=TASK)

#### Specified Reivewers:

/assign @Effet 

