### PR TITLE
feat: revert cp onlyReturnRendering temporarily

### DIFF
--- a/providers/component-protocol/protocol/render.go
+++ b/providers/component-protocol/protocol/render.go
@@ -138,7 +138,7 @@ func RunScenarioRender(ctx context.Context, req *cptype.ComponentProtocolRequest
 	}
 
 	posthook.HandleContinueRender(compRending, req.Protocol)
-	posthook.OnlyReturnRenderingComps(compRending, req.Protocol)
+	//posthook.OnlyReturnRenderingComps(compRending, req.Protocol)
 
 	return nil
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

revert cp onlyReturnRendering temporarily

waiting UI


#### Specified Reivewers:
/assign @Effet 

