### PR TITLE
feat: cp: component register decouple from servicehub-provider

### DIFF
--- a/providers/component-protocol/cpregister/register_comp.go
+++ b/providers/component-protocol/cpregister/register_comp.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cpregister
+
+import (
+	"reflect"
+
+	"github.com/erda-project/erda-infra/providers/component-protocol/cptype"
+	"github.com/erda-project/erda-infra/providers/component-protocol/protocol"
+)
+
+// RegisterComponent register legacy component which implements protocol.RenderCreator
+func RegisterComponent(scenario, componentName string, componentCreator protocol.ComponentCreator) {
+	protocol.MustRegisterComponent(&protocol.CompRenderSpec{
+		Scenario: scenario,
+		CompName: componentName,
+		RenderC:  nil,
+		Creator: func() cptype.IComponent {
+			compInstance := componentCreator()
+			ref := reflect.ValueOf(compInstance)
+			ref.Elem().FieldByName("Impl").Set(ref)
+			return compInstance
+		},
+	})
+}
+
+// RegisterLegacyComponent register legacy component which implements protocol.RenderCreator
+// For most scenarios, you should use RegisterComponent.
+func RegisterLegacyComponent(scenario, componentName string, componentCreator protocol.RenderCreator) {
+	protocol.MustRegisterComponent(&protocol.CompRenderSpec{
+		Scenario: scenario,
+		CompName: componentName,
+		RenderC:  componentCreator,
+		Creator:  nil,
+	})
+}

--- a/providers/component-protocol/examples/components/kanban_demo/kanban.http
+++ b/providers/component-protocol/examples/components/kanban_demo/kanban.http
@@ -1,0 +1,9 @@
+# kanban
+POST http://localhost:8080/api/component-protocol/actions/render
+Content-Type: application/json
+
+{
+  "scenario": {
+    "scenarioKey": "kanban-demo"
+  }
+}

--- a/providers/component-protocol/examples/components/kanban_demo/kanban/custom_type.go
+++ b/providers/component-protocol/examples/components/kanban_demo/kanban/custom_type.go
@@ -30,37 +30,37 @@ type CustomInParams struct {
 }
 
 // CustomStatePtr .
-func (p *provider) CustomStatePtr() interface{} {
-	if p.StatePtr == nil {
-		p.StatePtr = &CustomState{}
+func (c *component) CustomStatePtr() interface{} {
+	if c.StatePtr == nil {
+		c.StatePtr = &CustomState{}
 	}
-	return p.StatePtr
+	return c.StatePtr
 }
 
 // EncodeFromCustomState .
-func (p *provider) EncodeFromCustomState(customStatePtr interface{}, stdStatePtr *cptype.ExtraMap) {
+func (c *component) EncodeFromCustomState(customStatePtr interface{}, stdStatePtr *cptype.ExtraMap) {
 	cputil.MustObjJSONTransfer(customStatePtr, stdStatePtr)
 }
 
 // DecodeToCustomState .
-func (p *provider) DecodeToCustomState(stdStatePtr *cptype.ExtraMap, customStatePtr interface{}) {
+func (c *component) DecodeToCustomState(stdStatePtr *cptype.ExtraMap, customStatePtr interface{}) {
 	cputil.MustObjJSONTransfer(stdStatePtr, customStatePtr)
 }
 
 // CustomInParamsPtr .
-func (p *provider) CustomInParamsPtr() interface{} {
-	if p.InParamsPtr == nil {
-		p.InParamsPtr = &CustomInParams{}
+func (c *component) CustomInParamsPtr() interface{} {
+	if c.InParamsPtr == nil {
+		c.InParamsPtr = &CustomInParams{}
 	}
-	return p.InParamsPtr
+	return c.InParamsPtr
 }
 
 // EncodeFromCustomInParams .
-func (p *provider) EncodeFromCustomInParams(customInParamsPtr interface{}, stdInParamsPtr *cptype.ExtraMap) {
+func (c *component) EncodeFromCustomInParams(customInParamsPtr interface{}, stdInParamsPtr *cptype.ExtraMap) {
 	cputil.MustObjJSONTransfer(customInParamsPtr, stdInParamsPtr)
 }
 
 // DecodeToCustomInParams .
-func (p *provider) DecodeToCustomInParams(stdInParamsPtr *cptype.ExtraMap, customInParamsPtr interface{}) {
+func (c *component) DecodeToCustomInParams(stdInParamsPtr *cptype.ExtraMap, customInParamsPtr interface{}) {
 	cputil.MustObjJSONTransfer(stdInParamsPtr, customInParamsPtr)
 }

--- a/providers/component-protocol/examples/components/kanban_demo/kanban/init.go
+++ b/providers/component-protocol/examples/components/kanban_demo/kanban/init.go
@@ -16,11 +16,22 @@ package kanban
 
 import (
 	"github.com/erda-project/erda-infra/base/servicehub"
-	"github.com/erda-project/erda-infra/providers/component-protocol/cpregister/base"
+	"github.com/erda-project/erda-infra/providers/component-protocol/cpregister"
+	"github.com/erda-project/erda-infra/providers/component-protocol/cptype"
 )
 
 func init() {
-	base.InitProviderWithCreator("kanban-demo", "kanban", func() servicehub.Provider { return &provider{} })
-	base.InitProviderWithCreator("kanban-demo", "xxx", func() servicehub.Provider { return &provider{} })
-	base.InitProviderWithCreator("kanban-demo", "sssss", func() servicehub.Provider { return &provider{} })
+	// register provider
+	servicehub.Register("your-provider-name", &servicehub.Spec{
+		Dependencies: []string{"i18n"},
+		Creator:      func() servicehub.Provider { return &component{} },
+	})
+}
+
+func (c *component) Init(ctx servicehub.Context) error {
+	// register component
+	cpregister.RegisterComponent("kanban-demo", "xxx", func() cptype.IComponent { return c })
+	cpregister.RegisterComponent("kanban-demo", "sssss", func() cptype.IComponent { return c })
+	cpregister.RegisterComponent("kanban-demo", "kanban", func() cptype.IComponent { return c })
+	return nil
 }

--- a/providers/component-protocol/examples/demo.yaml
+++ b/providers/component-protocol/examples/demo.yaml
@@ -15,3 +15,5 @@ i18n:
 
 # component-protocol framework
 component-protocol:
+
+your-provider-name:

--- a/providers/component-protocol/examples/i18n/scenarios/notbelong.yaml
+++ b/providers/component-protocol/examples/i18n/scenarios/notbelong.yaml
@@ -1,0 +1,4 @@
+zh:
+  hello: 你好
+en:
+  hello: hi


### PR DESCRIPTION
#### What this PR does / why we need it:

decouple component's register from servicehub-provider

#### Which issue(s) this PR fixes:

[Erda Issue](https://erda.cloud/erda/dop/projects/387/issues/all?id=275738&issueFilter__urlQuery=eyJ0aXRsZSI6Iue7hOS7tiIsInN0YXRlcyI6WzQ0MDIsNzEwNCw3MTA1LDQ0MDMsNDQwNCw3MTA2LDQ0MDYsNDQwNyw0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=TASK)

#### Specified Reivewers:
/assign @Effet 

