### PR TITLE
feat: cp: optionally register component as provider

### DIFF
--- a/providers/component-protocol/cpregister/base/comp_register.go
+++ b/providers/component-protocol/cpregister/base/comp_register.go
@@ -21,6 +21,7 @@ import (
 	"github.com/erda-project/erda-infra/providers/component-protocol/cpregister"
 	"github.com/erda-project/erda-infra/providers/component-protocol/cptype"
 	"github.com/erda-project/erda-infra/providers/component-protocol/protocol"
+	"github.com/erda-project/erda-infra/providers/component-protocol/utils/cputil"
 )
 
 type creators struct {
@@ -46,7 +47,7 @@ func InitProviderWithCreator(scenario, compName string, creator servicehub.Creat
 // initProviderToNamespace register component as provider to specific namespace.
 func initProviderToNamespace(scenario, compName string, creator servicehub.Creator) {
 	// generate std providerName
-	providerName := MakeComponentProviderName(scenario, compName)
+	providerName := cputil.MakeComponentProviderName(scenario, compName)
 	if creator == nil {
 		creator = func() servicehub.Provider { return &DefaultProvider{} }
 	}

--- a/providers/component-protocol/cpregister/register_comp_provider.go
+++ b/providers/component-protocol/cpregister/register_comp_provider.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cpregister
+
+import (
+	"github.com/erda-project/erda-infra/base/servicehub"
+	"github.com/erda-project/erda-infra/providers/component-protocol/cptype"
+	"github.com/erda-project/erda-infra/providers/component-protocol/utils/cputil"
+)
+
+// ComponentCreatorAndProvider used for RegisterProviderComponent.
+type ComponentCreatorAndProvider interface {
+	cptype.IComponent
+	servicehub.Provider
+}
+
+// Option represents options when register.
+type Option struct {
+	providerSpec *servicehub.Spec
+}
+
+// OpFunc do function for option.
+type OpFunc func(*Option)
+
+// WithCustomProviderSpecButCreator use custom spec as base but ignore creator.
+func (o *Option) WithCustomProviderSpecButCreator(spec *servicehub.Spec) {
+	o.providerSpec = spec
+}
+
+// RegisterProviderComponent register a provider to component. Normally this provider will use servicehub's auto dependency injection feature.
+func RegisterProviderComponent(scenario, componentName string, providerPtr ComponentCreatorAndProvider, opFuncs ...OpFunc) {
+	// handle options
+	opt := Option{
+		providerSpec: &servicehub.Spec{},
+	}
+	for _, opFunc := range opFuncs {
+		opFunc(&opt)
+	}
+
+	// generate provider name
+	providerName := cputil.MakeComponentProviderName(scenario, componentName)
+
+	// register component
+	RegisterComponent(scenario, componentName, func() cptype.IComponent { return providerPtr })
+
+	// register as provider
+	opt.providerSpec.Creator = func() servicehub.Provider { return providerPtr }
+	servicehub.Register(providerName, opt.providerSpec)
+
+	// mark for auto servicehub config adding
+	AllExplicitProviderCreatorMap[providerName] = nil
+}

--- a/providers/component-protocol/examples/components/kanban_demo/kanban/init.go
+++ b/providers/component-protocol/examples/components/kanban_demo/kanban/init.go
@@ -17,21 +17,14 @@ package kanban
 import (
 	"github.com/erda-project/erda-infra/base/servicehub"
 	"github.com/erda-project/erda-infra/providers/component-protocol/cpregister"
-	"github.com/erda-project/erda-infra/providers/component-protocol/cptype"
 )
 
 func init() {
-	// register provider
-	servicehub.Register("your-provider-name", &servicehub.Spec{
-		Dependencies: []string{"i18n"},
-		Creator:      func() servicehub.Provider { return &component{} },
-	})
+	cpregister.RegisterProviderComponent("kanban-demo", "kanban", &component{})
+	cpregister.RegisterProviderComponent("kanban-demo", "xxx", &component{})
+	cpregister.RegisterProviderComponent("kanban-demo", "sssss", &component{})
 }
 
 func (c *component) Init(ctx servicehub.Context) error {
-	// register component
-	cpregister.RegisterComponent("kanban-demo", "xxx", func() cptype.IComponent { return c })
-	cpregister.RegisterComponent("kanban-demo", "sssss", func() cptype.IComponent { return c })
-	cpregister.RegisterComponent("kanban-demo", "kanban", func() cptype.IComponent { return c })
 	return nil
 }

--- a/providers/component-protocol/examples/demo.yaml
+++ b/providers/component-protocol/examples/demo.yaml
@@ -15,5 +15,3 @@ i18n:
 
 # component-protocol framework
 component-protocol:
-
-your-provider-name:

--- a/providers/component-protocol/utils/cputil/provider_name.go
+++ b/providers/component-protocol/utils/cputil/provider_name.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package base
+package cputil
 
 import (
 	"fmt"

--- a/providers/component-protocol/utils/cputil/provider_name_test.go
+++ b/providers/component-protocol/utils/cputil/provider_name_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package base
+package cputil
 
 import (
 	"testing"


### PR DESCRIPTION
#### What this PR does / why we need it:

Sometimes, a component is a provider first, then become a component.
For this situation, we provide a more convenient method to use.

Previous:
![image](https://user-images.githubusercontent.com/13919034/149511276-5accb7e7-99f4-42a4-9477-7ac5ae5a4a37.png)


Now:
![image](https://user-images.githubusercontent.com/13919034/149511248-845584d0-8c04-43ee-9e7d-1a433c8e6bcf.png)



#### Specified Reivewers:
/assign @Effet 

