### PR TITLE
cp: reopen onlyReturnRendering

### DIFF
--- a/providers/component-protocol/protocol/render.go
+++ b/providers/component-protocol/protocol/render.go
@@ -138,7 +138,7 @@ func RunScenarioRender(ctx context.Context, req *cptype.ComponentProtocolRequest
 	}
 
 	posthook.HandleContinueRender(compRending, req.Protocol)
-	//posthook.OnlyReturnRenderingComps(compRending, req.Protocol)
+	posthook.OnlyReturnRenderingComps(compRending, req.Protocol)
 
 	return nil
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

cp: reopen onlyReturnRendering

erda-ui supported and cherry-picked to release/1.6 already.

#### Specified Reivewers:

/assign @Effet 

