### PR TITLE
fix: move ReturnAllComponents option check into func OnlyReturnRenderingComps

### DIFF
--- a/providers/component-protocol/protocol/posthook/only_return_rendering.go
+++ b/providers/component-protocol/protocol/posthook/only_return_rendering.go
@@ -20,6 +20,9 @@ import (
 
 // OnlyReturnRenderingComps only return rendering components.
 func OnlyReturnRenderingComps(renderingItems []cptype.RendingItem, req *cptype.ComponentProtocol) {
+	if req.Options != nil && req.Options.ReturnAllComponents {
+		return
+	}
 	// init new components map
 	onlyReturnComps := make(map[string]*cptype.Component, len(req.Components))
 	// construct map for easy use

--- a/providers/component-protocol/protocol/render.go
+++ b/providers/component-protocol/protocol/render.go
@@ -197,9 +197,7 @@ func doSerialCompsRendering(ctx context.Context, req *cptype.ComponentProtocolRe
 
 func posthookForCompsRendering(renderingItems []cptype.RendingItem, req *cptype.ComponentProtocolRequest) {
 	posthook.HandleContinueRender(renderingItems, req.Protocol)
-	if req.Protocol != nil && req.Protocol.Options != nil && !req.Protocol.Options.ReturnAllComponents {
-		posthook.OnlyReturnRenderingComps(renderingItems, req.Protocol)
-	}
+	posthook.OnlyReturnRenderingComps(renderingItems, req.Protocol)
 }
 
 func polishComponentRendering(debugOptions *cptype.ComponentProtocolDebugOptions, compRendering []cptype.RendingItem) []cptype.RendingItem {


### PR DESCRIPTION
#### What this PR does / why we need it:

fix: move ReturnAllComponents option check into func OnlyReturnRenderingComps

#### Which issue(s) this PR fixes:
Fixes #

#### Specified Reivewers:
/assign @sfwn 

