### PR TITLE
feat: cp add simplify-protocol posthook

### DIFF
--- a/providers/component-protocol/protocol/posthook/simplify.go
+++ b/providers/component-protocol/protocol/posthook/simplify.go
@@ -39,7 +39,8 @@ func simplifyComp(comp *cptype.Component) {
 		if comp.Options.Visible &&
 			!comp.Options.AsyncAtInit &&
 			!comp.Options.FlatExtra &&
-			!comp.Options.RemoveExtraAfterFlat {
+			!comp.Options.RemoveExtraAfterFlat &&
+			comp.Options.ContinueRender == nil || len(comp.Options.ContinueRender.OpKey) == 0 {
 			comp.Options = nil
 		}
 	}

--- a/providers/component-protocol/protocol/posthook/simplify.go
+++ b/providers/component-protocol/protocol/posthook/simplify.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package posthook
+
+import (
+	"github.com/erda-project/erda-infra/providers/component-protocol/cptype"
+)
+
+// SimplifyProtocol simplify protocol if could.
+func SimplifyProtocol(renderingItems []cptype.RendingItem, req *cptype.ComponentProtocol) {
+	for _, comp := range req.Components {
+		simplifyComp(comp)
+	}
+}
+
+func simplifyComp(comp *cptype.Component) {
+	if len(comp.Data) == 0 {
+		comp.Data = nil
+	}
+	if len(comp.State) == 0 {
+		comp.State = nil
+	}
+	if len(comp.Operations) == 0 {
+		comp.Operations = nil
+	}
+	if comp.Options != nil {
+		if comp.Options.Visible &&
+			!comp.Options.AsyncAtInit &&
+			!comp.Options.FlatExtra &&
+			!comp.Options.RemoveExtraAfterFlat {
+			comp.Options = nil
+		}
+	}
+	if len(comp.Props) == 0 {
+		comp.Props = nil
+	}
+}

--- a/providers/component-protocol/protocol/posthook/simplify_test.go
+++ b/providers/component-protocol/protocol/posthook/simplify_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package posthook
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda-infra/providers/component-protocol/cptype"
+)
+
+func Test_simplifyComp(t *testing.T) {
+	c1 := &cptype.Component{
+		Data: map[string]interface{}{},
+		State: map[string]interface{}{
+			"A": "B",
+		},
+		Options: &cptype.ComponentOptions{
+			Visible:              false,
+			AsyncAtInit:          false,
+			ContinueRender:       &cptype.ContinueRender{OpKey: ""},
+			FlatExtra:            false,
+			RemoveExtraAfterFlat: false,
+		},
+	}
+	simplifyComp(c1)
+	assert.Nil(t, c1.Data)
+	assert.NotNil(t, c1.State)
+	assert.Nil(t, c1.Options)
+
+	b, err := json.Marshal(c1)
+	assert.NoError(t, err)
+	fmt.Println(string(b))
+}

--- a/providers/component-protocol/protocol/render.go
+++ b/providers/component-protocol/protocol/render.go
@@ -198,6 +198,7 @@ func doSerialCompsRendering(ctx context.Context, req *cptype.ComponentProtocolRe
 func posthookForCompsRendering(renderingItems []cptype.RendingItem, req *cptype.ComponentProtocolRequest) {
 	posthook.HandleContinueRender(renderingItems, req.Protocol)
 	posthook.OnlyReturnRenderingComps(renderingItems, req.Protocol)
+	posthook.SimplifyProtocol(renderingItems, req.Protocol)
 }
 
 func polishComponentRendering(debugOptions *cptype.ComponentProtocolDebugOptions, compRendering []cptype.RendingItem) []cptype.RendingItem {
@@ -376,29 +377,6 @@ func getDefaultHierarchyRenderOrderFromCompExclude(fullOrders []string, startFro
 	return fullOrders[fromIdx+1:]
 }
 
-func simplifyComp(comp *cptype.Component) {
-	if len(comp.Data) == 0 {
-		comp.Data = nil
-	}
-	if len(comp.State) == 0 {
-		comp.State = nil
-	}
-	if len(comp.Operations) == 0 {
-		comp.Operations = nil
-	}
-	if comp.Options != nil {
-		if comp.Options.Visible &&
-			!comp.Options.AsyncAtInit &&
-			!comp.Options.FlatExtra &&
-			!comp.Options.RemoveExtraAfterFlat {
-			comp.Options = nil
-		}
-	}
-	if len(comp.Props) == 0 {
-		comp.Props = nil
-	}
-}
-
 func renderOneComp(ctx context.Context, req *cptype.ComponentProtocolRequest, sr ScenarioRender, v cptype.RendingItem) error {
 	// 组件状态渲染
 	err := protoCompStateRending(ctx, req.Protocol, v)
@@ -429,7 +407,6 @@ func renderOneComp(ctx context.Context, req *cptype.ComponentProtocolRequest, sr
 		logrus.Errorf("render component failed, err: %s, scenario: %+v, component: %s", err.Error(), req.Scenario, cr.CompName)
 		return err
 	}
-	simplifyComp(c)
 	elapsed := time.Since(start)
 	logrus.Infof("[component render time cost] scenario: %s, component: %s, cost: %s", req.Scenario.ScenarioKey, v.Name, elapsed)
 	return nil


### PR DESCRIPTION
#### What this PR does / why we need it:

cp: add simplify-protocol posthook, so both std and non-std comp can use it.

#### Specified Reivewers:
/assign @Effet 

