### PR TITLE
feat: logger use provider key as module name to distinguish multiple provider instances

### DIFF
--- a/base/servicehub/provider_context.go
+++ b/base/servicehub/provider_context.go
@@ -262,7 +262,7 @@ func (c *providerContext) Logger() logs.Logger {
 	if c.hub.logger == nil {
 		return nil
 	}
-	return c.hub.logger.Sub(c.name)
+	return c.hub.logger.Sub(c.key)
 }
 
 // Config .


### PR DESCRIPTION
#### What this PR does / why we need it:

logger use provider key as module name to distinguish multiple provider instances

#### Specified Reivewers:

/assign @recallsong 

#### Screenshots

before: 
<img width="676" alt="image" src="https://user-images.githubusercontent.com/13919034/155173106-b7151b59-ec35-43f1-8bd2-847c710d6394.png">

now:
<img width="271" alt="image" src="https://user-images.githubusercontent.com/13919034/155172890-370aafe5-86a9-4eb8-bb8a-d1b0b6210bfc.png">

