### PR TITLE
feature: logger force color

### DIFF
--- a/base/logs/logrusx/log.go
+++ b/base/logs/logrusx/log.go
@@ -15,8 +15,9 @@
 package logrusx
 
 import (
-	"github.com/erda-project/erda-infra/base/logs"
 	"github.com/sirupsen/logrus"
+
+	"github.com/erda-project/erda-infra/base/logs"
 )
 
 // Logger .
@@ -29,7 +30,7 @@ type Logger struct {
 func New(options ...Option) logs.Logger {
 	log := logrus.New()
 	log.SetFormatter(&logrus.TextFormatter{
-		ForceColors:     false,
+		ForceColors:     true,
 		FullTimestamp:   true,
 		TimestampFormat: "2006-01-02 15:04:05.000",
 	})


### PR DESCRIPTION
#### What this PR does / why we need it:

logger force color to pretty log as local.

before:
<img width="859" alt="image" src="https://user-images.githubusercontent.com/13919034/156313010-5136a416-76f2-417b-85b3-01828e8026c9.png">


after:
<img width="1118" alt="image" src="https://user-images.githubusercontent.com/13919034/156312980-d629baa9-17da-4b83-972a-5a4eaef87eeb.png">


#### Specified Reivewers:
/assign @Effet 

