### PR TITLE
chore: enlarge mysql max open/idle connections

### DIFF
--- a/providers/mysql/mysql.go
+++ b/providers/mysql/mysql.go
@@ -44,8 +44,8 @@ type config struct {
 	MySQLUsername       string        `file:"username" env:"MYSQL_USERNAME" default:"root"`
 	MySQLPassword       string        `file:"password" env:"MYSQL_PASSWORD" default:""`
 	MySQLDatabase       string        `file:"database" env:"MYSQL_DATABASE"`
-	MySQLMaxIdleConns   uint64        `file:"max_idle_conns" env:"MYSQL_MAXIDLECONNS" default:"1"`
-	MySQLMaxOpenConns   uint64        `file:"max_open_conns" env:"MYSQL_MAXOPENCONNS" default:"2"`
+	MySQLMaxIdleConns   uint64        `file:"max_idle_conns" env:"MYSQL_MAXIDLECONNS" default:"10"`
+	MySQLMaxOpenConns   uint64        `file:"max_open_conns" env:"MYSQL_MAXOPENCONNS" default:"20"`
 	MySQLMaxLifeTime    time.Duration `file:"max_lifetime" env:"MYSQL_MAXLIFETIME" default:"30m"`
 	MySQLDebug          bool          `file:"debug" env:"MYSQL_DEBUG" default:"false"`
 	MySQLCharset        string        `file:"charset" env:"MYSQL_CHARSET" default:"utf8mb4"`

--- a/providers/mysqlxorm/xorm.go
+++ b/providers/mysqlxorm/xorm.go
@@ -47,8 +47,8 @@ type config struct {
 	MySQLUsername       string        `file:"username" env:"MYSQL_USERNAME" default:"root"`
 	MySQLPassword       string        `file:"password" env:"MYSQL_PASSWORD" default:""`
 	MySQLDatabase       string        `file:"database" env:"MYSQL_DATABASE"`
-	MySQLMaxIdleConns   uint64        `file:"max_idle_conns" env:"MYSQL_MAXIDLECONNS" default:"1"`
-	MySQLMaxOpenConns   uint64        `file:"max_open_conns" env:"MYSQL_MAXOPENCONNS" default:"2"`
+	MySQLMaxIdleConns   uint64        `file:"max_idle_conns" env:"MYSQL_MAXIDLECONNS" default:"10"`
+	MySQLMaxOpenConns   uint64        `file:"max_open_conns" env:"MYSQL_MAXOPENCONNS" default:"20"`
 	MySQLMaxLifeTime    time.Duration `file:"max_lifetime" env:"MYSQL_MAXLIFETIME" default:"30m"`
 	MySQLShowSQL        bool          `file:"show_sql" env:"MYSQL_SHOW_SQL" default:"false"`
 	MySQLProperties     string        `file:"properties" env:"MYSQL_PROPERTIES" default:"charset=utf8mb4&collation=utf8mb4_unicode_ci&parseTime=True&loc=Local"`


### PR DESCRIPTION
#### What this PR does / why we need it:

enlarge mysql max open/idle connections.
currently, 1(idle)/2(max) is too small.

#### Specified Reivewers:
/assign @Effet @littlejiancc 

