### PR TITLE
fix: golangci-lint issue of go 1.18

### DIFF
--- a/.github/workflows/ci-it.yml
+++ b/.github/workflows/ci-it.yml
@@ -12,28 +12,13 @@ jobs:
   CI:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.16
+          go-version: 1.17
       - name: Run Lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.38
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-          # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
-          # Optional: if set to true then the action will use pre-installed Go.
-          # skip-go-installation: true
-          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
-          # skip-pkg-cache: true
-          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
-          # skip-build-cache: true
+        uses: golangci/golangci-lint-action@v3
       - name: Run Test
         run: |
           go test -cpu=2 -timeout 10s -race -coverprofile=coverage.txt -covermode=atomic ./...


### PR DESCRIPTION
#### What this PR does / why we need it:

fix golangci-lint issue of go 1.18

#### Which issue(s) this PR fixes:
Fixes #

#### Specified Reivewers:
/assign @Effet 

