### PR TITLE
kafkav2 based on kafak-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
-	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/yamux v0.0.0-20210826001029-26ff87cf9493
 	github.com/jackc/pgx v3.6.2+incompatible // indirect
 	github.com/jinzhu/gorm v1.9.16
@@ -41,17 +41,18 @@ require (
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.3.0
 	github.com/leodido/go-urn v1.2.1 // indirect
-	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/magiconair/properties v1.8.5
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/mitchellh/mapstructure v1.1.2
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/mwitkow/go-proto-validators v0.3.2
 	github.com/olivere/elastic v6.2.35+incompatible
-	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pelletier/go-toml v1.9.4
 	github.com/prometheus/client_golang v1.10.0
 	github.com/recallsong/go-utils v1.1.2-0.20210826100715-fce05eefa294
 	github.com/recallsong/unmarshal v1.0.0
 	github.com/satori/go.uuid v1.2.0
+	github.com/segmentio/kafka-go v0.4.31
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
@@ -75,8 +76,8 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/flosch/pongo2.v3 v3.0.0-20141028000813-5e81b817a0c4 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
-	gopkg.in/ini.v1 v1.63.2 // indirect
-	gopkg.in/yaml.v2 v2.3.0 // indirect
+	gopkg.in/ini.v1 v1.63.2
+	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	gorm.io/driver/mysql v1.3.2
 	gorm.io/driver/sqlite v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -299,6 +299,8 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.14.2 h1:S0OHlFk/Gbon/yauFJ4FfJJF5V0fc5HbBTJazi28pRw=
+github.com/klauspost/compress v1.14.2/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -465,6 +467,8 @@ github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/segmentio/kafka-go v0.4.31 h1:+ImsrkJRju9j1D9U44rvRGRlpsI9GnwD8s9WTFagNLQ=
+github.com/segmentio/kafka-go v0.4.31/go.mod h1:m1lXeqJtIFYZayv0shM/tjrAFljvWLTprxBHd+3PnaU=
 github.com/shirou/gopsutil v2.19.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
@@ -508,6 +512,10 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.2.1 h1:TVEnxayobAdVkhQfrfes2IzOB6o+z4roRkPF52WA1u4=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
+github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=
+github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
+github.com/xdg/stringprep v1.0.0 h1:d9X0esnoa3dFsV0FG35rAT0RIhYFlPq7MiP+DW89La0=
+github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xormplus/builder v0.0.0-20181220055446-b12ceebee76f h1:1kd2rgJuSRqTCUSqFkKuaUNsNogLzjPhC9Pr8qnhZDs=
@@ -563,6 +571,7 @@ golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190506204251-e1dfcc566284/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/providers/all.go
+++ b/providers/all.go
@@ -28,6 +28,7 @@ import (
 	_ "github.com/erda-project/erda-infra/providers/httpserver"            //
 	_ "github.com/erda-project/erda-infra/providers/i18n"                  //
 	_ "github.com/erda-project/erda-infra/providers/kafka"                 //
+	_ "github.com/erda-project/erda-infra/providers/kafkav2"               //
 	_ "github.com/erda-project/erda-infra/providers/kubernetes"            //
 	_ "github.com/erda-project/erda-infra/providers/mysql"                 //
 	_ "github.com/erda-project/erda-infra/providers/pprof"                 //

--- a/providers/kafkav2/examples/producer/examples.yaml
+++ b/providers/kafkav2/examples/producer/examples.yaml
@@ -1,0 +1,4 @@
+kafka-v2:
+  servers: "localhost:9092"
+
+examples:

--- a/providers/kafkav2/kafka.go
+++ b/providers/kafkav2/kafka.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafkav2
+
+import (
+	"reflect"
+
+	"github.com/erda-project/erda-infra/base/logs"
+	"github.com/erda-project/erda-infra/base/servicehub"
+	writer "github.com/erda-project/erda-infra/pkg/parallel-writer"
+)
+
+// Interface .
+type Interface interface {
+	NewProducer(c ProducerConfig, options ...ProducerOption) (writer.Writer, error)
+	Servers() string
+}
+
+// Producer .
+type Producer interface {
+	writer.Writer
+}
+
+type config struct {
+	Servers string `file:"servers" env:"BOOTSTRAP_SERVERS" default:"localhost:9092" desc:"kafka servers"`
+}
+
+// provider .
+type provider struct {
+	Cfg *config
+	Log logs.Logger
+}
+
+// Init .
+func (p *provider) Init(ctx servicehub.Context) error {
+	return nil
+}
+
+// Provide .
+func (p *provider) Provide(ctx servicehub.DependencyContext, options ...interface{}) interface{} {
+	return &service{
+		p:    p,
+		log:  p.Log.Sub(ctx.Caller()),
+		name: ctx.Caller(),
+	}
+}
+
+type service struct {
+	p    *provider
+	log  logs.Logger
+	name string
+}
+
+var _ Interface = (*service)(nil)
+
+func (s *service) Servers() string { return s.p.Cfg.Servers }
+
+func init() {
+	servicehub.Register("kafka-v2", &servicehub.Spec{
+		Services: []string{"kafka-v2", "kafka-producer-v2"},
+		Types: []reflect.Type{
+			reflect.TypeOf((*Interface)(nil)).Elem(),
+		},
+		ConfigFunc: func() interface{} { return &config{} },
+		Creator: func() servicehub.Provider {
+			return &provider{}
+		},
+	})
+}

--- a/providers/kafkav2/producer.go
+++ b/providers/kafkav2/producer.go
@@ -1,0 +1,174 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafkav2
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/recallsong/go-utils/reflectx"
+	"github.com/segmentio/kafka-go"
+
+	"github.com/erda-project/erda-infra/base/logs"
+	writer "github.com/erda-project/erda-infra/pkg/parallel-writer"
+)
+
+// Message .
+type Message struct {
+	Topic string
+	Data  []byte
+	Key   []byte
+}
+
+// ProducerConfig .
+type ProducerConfig struct {
+	Topic       string        `file:"topic"`
+	Parallelism uint64        `file:"parallelism"  default:"3" env:"PROVIDER_KAFKA_V2_PRODUCER_PARALLELISM"`
+	Async       bool          `file:"async" default:"true" env:"PROVIDER_KAFKA_V2_PRODUCER_ASYNC"`
+	Timeout     time.Duration `file:"timeout" default:"30s" env:"PROVIDER_KAFKA_V2_PRODUCER_TIMEOUT"`
+	Batch       struct {
+		Size      int           `file:"size" default:"100" env:"PROVIDER_KAFKA_V2_PRODUCER_BATCH_SIZE"`
+		SizeBytes int64         `file:"size_bytes" default:"1048576" env:"PROVIDER_KAFKA_V2_PRODUCER_BATCH_SIZE_BYTES"`
+		Timeout   time.Duration `file:"timeout" default:"800ms" env:"PROVIDER_KAFKA_V2_PRODUCER_BATCH_TIMEOUT"`
+	} `file:"batch"`
+}
+
+// ProducerOption .
+type ProducerOption interface {
+	errHandler() func(error) error
+}
+
+type producerOption struct{ _eh func(error) error }
+
+func (p *producerOption) errHandler() func(error) error { return p._eh }
+
+// WithAsyncWriteErrorHandler .
+func WithAsyncWriteErrorHandler(eh func(error) error) ProducerOption {
+	return &producerOption{_eh: eh}
+}
+
+func newProducer(servers string, cfg ProducerConfig, log logs.Logger) (*producer, error) {
+	prod := &producer{
+		logger: log,
+	}
+	pw := &kafka.Writer{
+		Addr:                   kafka.TCP(strings.Split(servers, ",")...),
+		Balancer:               kafka.CRC32Balancer{},
+		Async:                  cfg.Async,
+		AllowAutoTopicCreation: true,
+		WriteTimeout:           cfg.Timeout,
+		BatchSize:              cfg.Batch.Size,
+		BatchTimeout:           cfg.Batch.Timeout,
+		BatchBytes:             cfg.Batch.SizeBytes,
+	}
+	if cfg.Topic != "" {
+		pw.Topic = cfg.Topic
+	}
+	prod.pw = pw
+	return prod, nil
+}
+
+type producer struct {
+	logger logs.Logger
+	pw     *kafka.Writer
+}
+
+func (p *producer) Write(data interface{}) error {
+	return p.publish(data)
+}
+
+func (p *producer) WriteN(data ...interface{}) (int, error) {
+	for i, item := range data {
+		err := p.publish(item)
+		if err != nil {
+			return i, err
+		}
+	}
+	return len(data), nil
+}
+
+func (p *producer) publish(data interface{}) error {
+	var (
+		value []byte
+		key   []byte
+	)
+	topic := ""
+
+	switch val := data.(type) {
+	case Message:
+		if val.Topic != "" {
+			topic = val.Topic
+		}
+		value = val.Data
+		key = val.Key
+	case []byte:
+		value = val
+	case string:
+		value = reflectx.StringToBytes(val)
+	default:
+		data, err := json.Marshal(data)
+		if err != nil {
+			return err
+		}
+		value = data
+	}
+	if p.pw.Topic == "" {
+		err := p.pw.WriteMessages(context.TODO(), kafka.Message{
+			Topic: topic,
+			Key:   key,
+			Value: value,
+		})
+		if err != nil {
+			return err
+		}
+	} else {
+		err := p.pw.WriteMessages(context.TODO(), kafka.Message{
+			Key:   key,
+			Value: value,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *producer) Close() error {
+	return p.pw.Close()
+}
+
+func (s *service) NewProducer(cfg ProducerConfig, options ...ProducerOption) (writer.Writer, error) {
+	var eh writer.ErrorHandler = s.producerError
+	for _, item := range options {
+		if item != nil && item.errHandler() != nil {
+			eh = item.errHandler()
+		}
+	}
+	prod, err := newProducer(s.p.Cfg.Servers, cfg, s.log)
+	if err != nil {
+		return nil, err
+	}
+	return writer.ParallelBatch(func(uint64) writer.Writer {
+		return prod
+	}, cfg.Parallelism, 1, 0, eh), nil
+}
+
+func (s *service) producerError(err error) error {
+	s.log.Errorf("fail to write kafka: %s", err)
+	return nil // skip error
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
support new kafka provider based on [kafka-go](https://github.com/segmentio/kafka-go) which is a pure go libarary

#### Which issue(s) this PR fixes:
Fixes #

#### Specified Reivewers:
/assign @your-reviewer

