### PR TITLE
feat: allows to skip go-form

### DIFF
--- a/tools/protoc/protoc-gen-go-form/form.go
+++ b/tools/protoc/protoc-gen-go-form/form.go
@@ -45,9 +45,15 @@ func generateFile(gen *protogen.Plugin, file *protogen.File) (*protogen.Generate
 	g.P("// This is a compile-time assertion to ensure that this generated file")
 	g.P("// is compatible with the ", urlencPackage, " package it is being compiled against.")
 	for _, message := range file.Messages {
+		if strings.Contains(strings.ToUpper(message.Comments.Leading.String()), "+SKIP_GO-FORM") {
+			continue
+		}
 		g.P("var _ ", urlencPackage.Ident("URLValuesUnmarshaler"), " = ", "(*", message.GoIdent.GoName, ")(nil)")
 	}
 	for _, message := range file.Messages {
+		if strings.Contains(strings.ToUpper(message.Comments.Leading.String()), "+SKIP_GO-FORM") {
+			continue
+		}
 		err := genMessage(gen, file, g, message)
 		if err != nil {
 			return g, err


### PR DESCRIPTION
#### What this PR does / why we need it:
feat: allows to skip go-form

I have a struct whose fields refer to itself. The `protoc-gen-go-form` plugin will stack overflow when dealing with such structures. However, it is not necessary to generate go-form code for each message. I wish to provide a way for developers to skip it: include the specific string `+skip_go-form` in the comment of the message.

我有一个 proto message, 它的字段引用了它本身. `protoc-gen-go-form` 在处理这样的结构时会栈溢出而失败. 然而每个 message 都生成 go-form 代码并不是必须的, 因此我想提供一个方法来跳过执行 go-form: 在 message 的头上添加 `+skip_go-form` 这样的注释。

```proto
// +SKIP_GO-FORM
message Schema {

  string type = 5;
  string title = 6;
  string format = 7;
  string description = 8;

  bool deprecated = 20;

  Schema items = 30;
  repeated string required = 31;
  map<string, Schema> properties = 32;

}
```



#### Which issue(s) this PR fixes:
Fixes #

#### Specified Reivewers:
/assign @your-reviewer

