### PR TITLE
fix: Fix cp option visible can not be set to false.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,6 @@
 #### Which issue(s) this PR fixes:
 Fixes #
 
-#### Specified Reivewers:
+#### Specified Reviewers:
 /assign @your-reviewer
 

--- a/providers/component-protocol/protocol/posthook/simplify.go
+++ b/providers/component-protocol/protocol/posthook/simplify.go
@@ -25,6 +25,7 @@ func SimplifyProtocol(renderingItems []cptype.RendingItem, req *cptype.Component
 	}
 }
 
+// not simplify comp options as default value is needed。
 func simplifyComp(comp *cptype.Component) {
 	if len(comp.Data) == 0 {
 		comp.Data = nil
@@ -34,16 +35,6 @@ func simplifyComp(comp *cptype.Component) {
 	}
 	if len(comp.Operations) == 0 {
 		comp.Operations = nil
-	}
-	if comp.Options != nil {
-		if !comp.Options.Visible &&
-			!comp.Options.AsyncAtInit &&
-			!comp.Options.FlatExtra &&
-			!comp.Options.RemoveExtraAfterFlat &&
-			len(comp.Options.URLQuery) == 0 &&
-			(comp.Options.ContinueRender == nil || len(comp.Options.ContinueRender.OpKey) == 0) {
-			comp.Options = nil
-		}
 	}
 	if len(comp.Props) == 0 {
 		comp.Props = nil

--- a/providers/component-protocol/protocol/posthook/simplify_test.go
+++ b/providers/component-protocol/protocol/posthook/simplify_test.go
@@ -41,7 +41,7 @@ func Test_simplifyComp(t *testing.T) {
 	simplifyComp(c1)
 	assert.Nil(t, c1.Data)
 	assert.NotNil(t, c1.State)
-	assert.Nil(t, c1.Options)
+	assert.NotNil(t, c1.Options)
 
 	b, err := json.Marshal(c1)
 	assert.NoError(t, err)


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix cp option visible can not be set to false.

#### Which issue(s) this PR fixes:
https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb25JRHMiOlsxMTkwLDEyMTgsMTIyNF0sImFzc2lnbmVlIjpbIjEwMDEwNzMiXX0%3D&id=310462&iterationID=1190&pId=0&type=TASK

#### Specified Reviewers:
/assign @sfwn 

