### PR TITLE
feat: hub content config support env escape as file

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -138,11 +138,7 @@ func UnmarshalToMap(in io.Reader, typ string, c map[string]interface{}) (err err
 	if err != nil {
 		return err
 	}
-	byts := buf.Bytes()
-	byts = TrimBOM(byts)
-	byts = EscapeEnv(byts)
-	buf.Reset()
-	_, err = buf.Write(byts)
+	err = polishBuffer(buf)
 	if err != nil {
 		return err
 	}
@@ -206,6 +202,15 @@ func UnmarshalToMap(in io.Reader, typ string, c map[string]interface{}) (err err
 	}
 	toStringKeyMap(c)
 	return nil
+}
+
+func polishBuffer(buf *bytes.Buffer) error {
+	byts := buf.Bytes()
+	byts = TrimBOM(byts)
+	byts = EscapeEnv(byts)
+	buf.Reset()
+	_, err := buf.Write(byts)
+	return err
 }
 
 func toStringKeyMap(i interface{}) interface{} {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -134,7 +134,18 @@ func (pe ParseError) Error() string {
 // UnmarshalToMap .
 func UnmarshalToMap(in io.Reader, typ string, c map[string]interface{}) (err error) {
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(in)
+	_, err = buf.ReadFrom(in)
+	if err != nil {
+		return err
+	}
+	byts := buf.Bytes()
+	byts = TrimBOM(byts)
+	byts = EscapeEnv(byts)
+	buf.Reset()
+	_, err = buf.Write(byts)
+	if err != nil {
+		return err
+	}
 	switch strings.ToLower(typ) {
 	case "yaml", "yml":
 		if err = yaml.Unmarshal(buf.Bytes(), &c); err != nil {
@@ -270,10 +281,6 @@ func ConvertData(input, output interface{}, tag string) error {
 // LoadFile .
 func LoadFile(path string) ([]byte, error) {
 	byts, err := ioutil.ReadFile(path)
-	if err == nil {
-		byts = TrimBOM(byts)
-		byts = EscapeEnv(byts)
-	}
 	return byts, err
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -15,10 +15,12 @@
 package config
 
 import (
+	"bytes"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 )
 
 func Test_Multi_Non_Bool_Env_Replace(t *testing.T) {
@@ -128,4 +130,46 @@ example:
 	_ = os.Unsetenv("ES")
 	_ = os.Unsetenv("CK")
 
+}
+
+func Test_polishBuffer(t *testing.T) {
+	const envLocale = "LOCALE"
+	content := `
+i18n:
+  LOCALE: "${LOCALE:zh-CN}"
+  num: 1
+`
+
+	// init buf
+	buf := bytes.NewBufferString(content)
+	// polish buf
+	assert.NoError(t, polishBuffer(buf))
+	// unmarshal
+	cfg := map[string]interface{}{}
+	err := yaml.Unmarshal(buf.Bytes(), &cfg)
+	assert.NoError(t, err)
+	i18nCfg, ok := cfg["i18n"]
+	assert.True(t, ok)
+	c, ok := i18nCfg.(map[string]interface{})
+	assert.True(t, ok)
+	assert.True(t, c[envLocale] == "zh-CN")
+	assert.True(t, c["num"] == 1)
+
+	// set env
+	assert.NoError(t, os.Setenv(envLocale, "en-US"))
+	defer func() { _ = os.Unsetenv(envLocale) }()
+	// init buf
+	buf = bytes.NewBufferString(content)
+	// polish buf
+	assert.NoError(t, polishBuffer(buf))
+	// unmarshal
+	cfg = map[string]interface{}{}
+	err = yaml.Unmarshal(buf.Bytes(), &cfg)
+	assert.NoError(t, err)
+	i18nCfg, ok = cfg["i18n"]
+	assert.True(t, ok)
+	c, ok = i18nCfg.(map[string]interface{})
+	assert.True(t, ok)
+	assert.True(t, c[envLocale] == "en-US")
+	assert.True(t, c["num"] == 1)
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -173,3 +173,39 @@ i18n:
 	assert.True(t, c[envLocale] == "en-US")
 	assert.True(t, c["num"] == 1)
 }
+
+func TestUnmarshalToMap(t *testing.T) {
+	const envLocale = "LOCALE"
+	content := `
+i18n:
+  LOCALE: "${LOCALE:zh-CN}"
+  num: 1
+`
+
+	// init buf
+	buf := bytes.NewBufferString(content)
+	cfg := make(map[string]interface{})
+	// parse conf
+	assert.NoError(t, UnmarshalToMap(buf, "yaml", cfg))
+	i18nCfg, ok := cfg["i18n"]
+	assert.True(t, ok)
+	c, ok := i18nCfg.(map[string]interface{})
+	assert.True(t, ok)
+	assert.True(t, c[envLocale] == "zh-CN")
+	assert.True(t, c["num"] == 1)
+
+	// set env
+	assert.NoError(t, os.Setenv(envLocale, "en-US"))
+	defer func() { _ = os.Unsetenv(envLocale) }()
+	// init buf
+	buf = bytes.NewBufferString(content)
+	cfg = make(map[string]interface{})
+	// parse conf
+	assert.NoError(t, UnmarshalToMap(buf, "yaml", cfg))
+	i18nCfg, ok = cfg["i18n"]
+	assert.True(t, ok)
+	c, ok = i18nCfg.(map[string]interface{})
+	assert.True(t, ok)
+	assert.True(t, c[envLocale] == "en-US")
+	assert.True(t, c["num"] == 1)
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

content config support env escape as file

#### Specified Reivewers:
/assign @snakorse 

