### PR TITLE
feat: Support profile env

### DIFF
--- a/base/servicehub/hub.go
+++ b/base/servicehub/hub.go
@@ -475,6 +475,7 @@ func (h *Hub) Provider(name string) interface{} {
 type RunOptions struct {
 	Name       string
 	ConfigFile string
+	EnvProfile string
 	Content    interface{}
 	Format     string
 	Args       []string
@@ -486,7 +487,7 @@ func (h *Hub) RunWithOptions(opts *RunOptions) {
 	if len(name) <= 0 {
 		name = getAppName(opts.Args...)
 	}
-	config.LoadEnvFile()
+	config.LoadEnvFile(opts.EnvProfile)
 
 	var err error
 	var start bool

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -343,11 +343,19 @@ func LoadEnvFileWithPath(path string, override bool) {
 }
 
 // LoadEnvFile .
-func LoadEnvFile() {
+func LoadEnvFile(profile string) {
 	wd, err := os.Getwd()
 	if err != nil {
 		return
 	}
 	path := filepath.Join(wd, ".env")
 	LoadEnvFileWithPath(path, false)
+	LoadEnvFileByProfile(path, profile)
+}
+
+func LoadEnvFileByProfile(path, profile string) {
+	if profile != "" {
+		path = fmt.Sprintf("%s-%s", path, profile)
+		LoadEnvFileWithPath(path, true)
+	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -356,7 +356,7 @@ func LoadEnvFile(profile string) {
 // LoadEnvFileByProfile load env variables by profile file
 func LoadEnvFileByProfile(path, profile string) {
 	if profile != "" {
-		path = fmt.Sprintf("%s-%s", path, profile)
+		path = fmt.Sprintf("%s.%s", path, profile)
 		LoadEnvFileWithPath(path, true)
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -353,6 +353,7 @@ func LoadEnvFile(profile string) {
 	LoadEnvFileByProfile(path, profile)
 }
 
+// LoadEnvFileByProfile load env variables by profile file
 func LoadEnvFileByProfile(path, profile string) {
 	if profile != "" {
 		path = fmt.Sprintf("%s-%s", path, profile)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"testing"
 
+	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 )
@@ -208,4 +209,28 @@ i18n:
 	assert.True(t, ok)
 	assert.True(t, c[envLocale] == "en-US")
 	assert.True(t, c["num"] == 1)
+}
+
+func TestLoadEnvFileByProfile(t *testing.T) {
+	type args struct {
+		path    string
+		profile string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{"case1", args{
+			path:    "",
+			profile: "dev",
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			monkey.Patch(LoadEnvFileWithPath, func(path string, override bool) {})
+
+			LoadEnvFileByProfile(tt.args.path, tt.args.profile)
+		})
+	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Support profile env

env file reading priority:  .env > .env.profile, the environment variables in the profile file will override the .env file
