### PR TITLE
feat: DeletedAtStamp; gorm.v2 provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/mwitkow/go-proto-validators v0.3.2
 	github.com/olivere/elastic v6.2.35+incompatible
 	github.com/pelletier/go-toml v1.9.4
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.10.0
 	github.com/recallsong/go-utils v1.1.2-0.20210826100715-fce05eefa294
 	github.com/recallsong/unmarshal v1.0.0

--- a/providers/mysql/v2/mysql.go
+++ b/providers/mysql/v2/mysql.go
@@ -116,6 +116,8 @@ func (p *provider) Init(ctx servicehub.Context) error {
 	if p.Cfg.MySQLDebug {
 		p.db = p.db.Debug()
 	}
+
+	Init(p.db)
 	return nil
 }
 

--- a/providers/mysql/v2/mysql.go
+++ b/providers/mysql/v2/mysql.go
@@ -51,8 +51,11 @@ func init() {
 
 // Interface .
 type Interface interface {
+	// DB returns the raw *gorm.DB.
 	DB() *gorm.DB
+	// Q returns the CRUD APIs without a transaction.
 	Q() *TX
+	// Begin returns the CRUD APIs with a transaction.
 	Begin() *TX
 }
 
@@ -94,7 +97,7 @@ type provider struct {
 	tx  *TX
 }
 
-// Init .
+// Init implements servicehub.ProviderInitializer
 func (p *provider) Init(ctx servicehub.Context) error {
 	err := mysqldriver.OpenTLS(p.Cfg.MySQLTLS, p.Cfg.MySQLCaCertPath, p.Cfg.MySQLClientCertPath, p.Cfg.MySQLClientKeyPath)
 	if err != nil {
@@ -124,9 +127,10 @@ func (p *provider) Init(ctx servicehub.Context) error {
 	return nil
 }
 
-// DB .
+// DB implements Interface.DB
 func (p *provider) DB() *gorm.DB { return p.db }
 
+// Q implements Interface.Q
 func (p *provider) Q() *TX {
 	return &TX{
 		db:    p.db,
@@ -134,6 +138,7 @@ func (p *provider) Q() *TX {
 	}
 }
 
+// Begin implements Interface.Begin
 func (p *provider) Begin() *TX {
 	return &TX{
 		db:    p.db,
@@ -142,7 +147,7 @@ func (p *provider) Begin() *TX {
 	}
 }
 
-// Provide .
+// Provide implements servicehub.DependencyProvider
 func (p *provider) Provide(ctx servicehub.DependencyContext, args ...interface{}) interface{} {
 	if ctx.Service() == "mysql-gorm.v2-client" || ctx.Type() == gormType {
 		return p.db

--- a/providers/mysql/v2/option.go
+++ b/providers/mysql/v2/option.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+type Option interface {
+	With(db *gorm.DB) *gorm.DB
+}
+
+func WhereOption(format string, args ...interface{}) Option {
+	return whereOption{format: format, args: args}
+}
+
+func MapOption(m map[string]interface{}) Option {
+	return mapOption{m: m}
+}
+
+func ByIDOption(id interface{}) Option {
+	return byIDOption{id: id}
+}
+
+func InOption(col string, values map[interface{}]struct{}) Option {
+	return inOption{col: col, values: values}
+}
+
+func PageOption(pageSize, pageNo int) Option {
+	if pageSize < 0 {
+		pageSize = 0
+	}
+	if pageNo < 1 {
+		pageNo = 1
+	}
+	return pageOption{
+		pageNo:   pageNo,
+		pageSize: pageSize,
+	}
+}
+
+func OrderByOption(col string, order string) Option {
+	if !strings.EqualFold(order, "desc") && !strings.EqualFold(order, "acs") {
+		order = "desc"
+	}
+	return orderByOption{
+		col:   col,
+		order: order,
+	}
+}
+
+type whereOption struct {
+	format string
+	args   []interface{}
+}
+
+func (o whereOption) With(db *gorm.DB) *gorm.DB {
+	return db.Where(o.format, o.args...)
+}
+
+type mapOption struct {
+	m map[string]interface{}
+}
+
+func (o mapOption) With(db *gorm.DB) *gorm.DB {
+	return db.Where(o.m)
+}
+
+type byIDOption struct {
+	id interface{}
+}
+
+func (o byIDOption) With(db *gorm.DB) *gorm.DB {
+	return db.Where("id = ?", o.id)
+}
+
+type inOption struct {
+	col    string
+	values map[interface{}]struct{}
+}
+
+func (o inOption) With(db *gorm.DB) *gorm.DB {
+	var keys []interface{}
+	for k := range o.values {
+		keys = append(keys, k)
+	}
+	return db.Where(o.col+" IN (?)", keys)
+}
+
+type pageOption struct {
+	pageNo, pageSize int
+}
+
+func (o pageOption) With(db *gorm.DB) *gorm.DB {
+	return db.Limit(o.pageSize).Offset((o.pageNo - 1) * o.pageSize)
+}
+
+func (o pageOption) PageOption() {}
+
+type orderByOption struct {
+	col, order string
+}
+
+func (o orderByOption) With(db *gorm.DB) *gorm.DB {
+	return db.Order(o.col + " " + strings.ToUpper(o.order))
+}
+
+type deleteOption struct {
+	i interface{}
+}
+
+func (o deleteOption) With(db *gorm.DB) *gorm.DB {
+	return db.Delete(o.i)
+}
+
+type updatesOption struct {
+	i interface{}
+	v interface{}
+}
+
+func (o updatesOption) With(db *gorm.DB) *gorm.DB {
+	return db.Model(o.i).Updates(o.v)
+}
+
+type listOption struct {
+	i        interface{}
+	total    *int64
+	pageSize int
+	pageNo   int
+}
+
+func (o listOption) With(db *gorm.DB) *gorm.DB {
+	db.Statement.Dest = o.i
+	if o.pageNo > 0 && o.pageSize > 0 {
+		return db.Count(o.total).Limit(o.pageSize).Offset((o.pageNo - 1) * o.pageSize).Find(o.i)
+	}
+	return db.Count(o.total).Find(o.i)
+}
+
+type firstOption struct {
+	i interface{}
+}
+
+func (o firstOption) With(db *gorm.DB) *gorm.DB {
+	return db.First(o.i)
+}

--- a/providers/mysql/v2/option.go
+++ b/providers/mysql/v2/option.go
@@ -103,12 +103,11 @@ func (c column) In(values []interface{}) Option {
 }
 
 func (c column) InMap(values map[interface{}]struct{}) Option {
-	var values_ []interface{}
+	var list []interface{}
 	for key := range values {
-		values_ = append(values_, key)
+		list = append(list, key)
 	}
-	fmt.Printf("values_: %v", values_)
-	return c.In(values_)
+	return c.In(list)
 }
 
 func (c column) Like(value interface{}) Option {
@@ -164,6 +163,7 @@ type WhereValue interface {
 	In(cols ...string) Option
 }
 
+// Value .
 func Value(value interface{}) WhereValue {
 	return whereValue{value: value}
 }

--- a/providers/mysql/v2/option.go
+++ b/providers/mysql/v2/option.go
@@ -22,18 +22,23 @@ import (
 )
 
 var (
+	// DESC means select by DESC
 	DESC Order = "DESC"
-	ASC  Order = "ASC"
+	// ASC means select by ASC
+	ASC Order = "ASC"
 )
 
+// Option is the function processes *gorm.DB
 type Option func(db *gorm.DB) *gorm.DB
 
+// Column is an interface for shortcut of WhereColumn, OrderColumn, SetColumn
 type Column interface {
 	WhereColumn
 	OrderColumn
 	SetColumn
 }
 
+// WhereColumn contains options for conditions
 type WhereColumn interface {
 	Is(value interface{}) Option
 	In(values []interface{}) Option
@@ -45,27 +50,33 @@ type WhereColumn interface {
 	EqLessThan(value interface{}) Option
 }
 
+// OrderColumn contains order by options
 type OrderColumn interface {
 	DESC() Option
 	ASC() Option
 }
 
+// SetColumn is used in update statements
 type SetColumn interface {
 	Set(value interface{}) Option
 }
 
+// Where is the option for conditions
 func Where(format string, args ...interface{}) Option {
 	return func(db *gorm.DB) *gorm.DB {
 		return db.Where(format, args...)
 	}
 }
 
+// Wheres is the option for conditions.
+// the m can be a map or a struct.
 func Wheres(m interface{}) Option {
 	return func(db *gorm.DB) *gorm.DB {
 		return db.Where(m)
 	}
 }
 
+// Col returns a Column interface
 func Col(col string) Column {
 	return column{col: col}
 }
@@ -148,11 +159,12 @@ func (c column) Set(value interface{}) Option {
 	}
 }
 
+// WhereValue contains the option presents where the value in
 type WhereValue interface {
 	In(cols ...string) Option
 }
 
-func Value(value interface{}) whereValue {
+func Value(value interface{}) WhereValue {
 	return whereValue{value: value}
 }
 
@@ -166,6 +178,7 @@ func (w whereValue) In(cols ...string) Option {
 	}
 }
 
+// Paging returns an Option for selecting by paging
 func Paging(size, no int) Option {
 	if size < 0 {
 		size = 0
@@ -178,8 +191,10 @@ func Paging(size, no int) Option {
 	}
 }
 
+// Order .
 type Order string
 
+// OrderBy returns an Option for selecting order by some column
 func OrderBy(col string, order Order) Option {
 	if !strings.EqualFold(string(order), string(DESC)) &&
 		!strings.EqualFold(string(order), string(ASC)) {

--- a/providers/mysql/v2/plugins/fields/soft_delete.go
+++ b/providers/mysql/v2/plugins/fields/soft_delete.go
@@ -19,6 +19,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"reflect"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -68,14 +69,13 @@ func (n DeletedAt) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON .
 func (n *DeletedAt) UnmarshalJSON(b []byte) error {
-	if string(b) == "null" {
+	bs := string(b)
+	if strings.EqualFold(bs, "null") {
 		n.Valid = false
 		return nil
 	}
 	err := json.Unmarshal(b, &n.Time)
-	if err == nil {
-		n.Valid = true
-	}
+	n.Valid = err == nil
 	return err
 }
 

--- a/providers/mysql/v2/plugins/fields/soft_delete_stamp.go
+++ b/providers/mysql/v2/plugins/fields/soft_delete_stamp.go
@@ -26,16 +26,21 @@ import (
 	"gorm.io/gorm/schema"
 )
 
+// DeletedAtStamp is the field type for soft deleting with BIGINT type.
+// 0 or null presents not deleted, an UnixMilli timestamp presents deleted.
 type DeletedAtStamp sql.NullInt64
 
+// Scan .
 func (n *DeletedAtStamp) Scan(value interface{}) error {
 	return (*sql.NullInt64)(n).Scan(value)
 }
 
+// Value .
 func (n DeletedAtStamp) Value() (driver.Value, error) {
 	return (sql.NullInt64)(n).Value()
 }
 
+// MarshalJSON .
 func (n DeletedAtStamp) MarshalJSON() ([]byte, error) {
 	if n.Valid {
 		return json.Marshal(n.Int64)
@@ -43,6 +48,7 @@ func (n DeletedAtStamp) MarshalJSON() ([]byte, error) {
 	return json.Marshal(nil)
 }
 
+// UnmarshalJSON .
 func (n *DeletedAtStamp) UnmarshalJSON(b []byte) error {
 	bs := string(b)
 	if strings.EqualFold(bs, "null") {
@@ -55,22 +61,27 @@ func (n *DeletedAtStamp) UnmarshalJSON(b []byte) error {
 
 }
 
+// GormDataType .
 func (DeletedAtStamp) GormDataType() string {
 	return "BIGINT(20)"
 }
 
+// QueryClauses .
 func (DeletedAtStamp) QueryClauses(f *schema.Field) []clause.Interface {
 	return []clause.Interface{DeletedatstampQueryclause{Field: f}}
 }
 
+// UpdateClauses .
 func (DeletedAtStamp) UpdateClauses(f *schema.Field) []clause.Interface {
 	return []clause.Interface{DeletedAtStampUpdateClause{Field: f}}
 }
 
+// DeleteClauses .
 func (DeletedAtStamp) DeleteClauses(f *schema.Field) []clause.Interface {
 	return []clause.Interface{DeletedAtStampDeleteClause{Field: f}}
 }
 
+// CreateClauses .
 func (DeletedAtStamp) CreateClauses(f *schema.Field) []clause.Interface {
 	return []clause.Interface{DeletedAtStampCreateClause{Field: f}}
 }
@@ -79,20 +90,25 @@ type baseClause struct {
 	softDeletedMode string
 }
 
+// Name .
 func (baseClause) Name() string {
 	return ""
 }
 
+// Build .
 func (baseClause) Build(_ clause.Builder) {}
 
+// MergeClause .
 func (baseClause) MergeClause(_ *clause.Clause) {}
 
+// DeletedatstampQueryclause .
 type DeletedatstampQueryclause struct {
 	baseClause
 
 	Field *schema.Field
 }
 
+// ModifyStatement .
 func (qc DeletedatstampQueryclause) ModifyStatement(stmt *gorm.Statement) {
 	if _, ok := stmt.Clauses["soft_delete_enabled"]; !ok && !stmt.Statement.Unscoped {
 		if c, ok := stmt.Clauses["WHERE"]; ok {
@@ -118,18 +134,21 @@ func (qc DeletedatstampQueryclause) ModifyStatement(stmt *gorm.Statement) {
 	}
 }
 
+// DeletedAtStampUpdateClause .
 type DeletedAtStampUpdateClause struct {
 	baseClause
 
 	Field *schema.Field
 }
 
+// ModifyStatement .
 func (qc DeletedAtStampUpdateClause) ModifyStatement(stmt *gorm.Statement) {
 	if stmt.SQL.Len() == 0 && !stmt.Statement.Unscoped {
 		DeletedatstampQueryclause(qc).ModifyStatement(stmt)
 	}
 }
 
+// DeletedAtStampDeleteClause .
 type DeletedAtStampDeleteClause struct {
 	baseClause
 
@@ -167,12 +186,14 @@ func (sd DeletedAtStampDeleteClause) ModifyStatement(stmt *gorm.Statement) {
 	}
 }
 
+// DeletedAtStampCreateClause .
 type DeletedAtStampCreateClause struct {
 	baseClause
 
 	Field *schema.Field
 }
 
+// ModifyStatement .
 func (c DeletedAtStampCreateClause) ModifyStatement(stmt *gorm.Statement) {
 	if stmt.SQL.Len() == 0 && !stmt.Statement.Unscoped {
 		stmt.SetColumn(c.Field.Name, sql.NullInt64{Int64: 0, Valid: true})

--- a/providers/mysql/v2/plugins/fields/soft_delete_stamp.go
+++ b/providers/mysql/v2/plugins/fields/soft_delete_stamp.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fields
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"reflect"
+	"strings"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"gorm.io/gorm/schema"
+)
+
+type DeletedAtStamp sql.NullInt64
+
+func (n *DeletedAtStamp) Scan(value interface{}) error {
+	return (*sql.NullInt64)(n).Scan(value)
+}
+
+func (n DeletedAtStamp) Value() (driver.Value, error) {
+	return (sql.NullInt64)(n).Value()
+}
+
+func (n DeletedAtStamp) MarshalJSON() ([]byte, error) {
+	if n.Valid {
+		return json.Marshal(n.Int64)
+	}
+	return json.Marshal(nil)
+}
+
+func (n *DeletedAtStamp) UnmarshalJSON(b []byte) error {
+	bs := string(b)
+	if strings.EqualFold(bs, "null") {
+		n.Valid = false
+		return nil
+	}
+	err := json.Unmarshal(b, &n.Int64)
+	n.Valid = err == nil
+	return err
+
+}
+
+func (DeletedAtStamp) GormDataType() string {
+	return "BIGINT(20)"
+}
+
+func (DeletedAtStamp) QueryClauses(f *schema.Field) []clause.Interface {
+	return []clause.Interface{DeletedatstampQueryclause{Field: f}}
+}
+
+func (DeletedAtStamp) UpdateClauses(f *schema.Field) []clause.Interface {
+	return []clause.Interface{DeletedAtStampUpdateClause{Field: f}}
+}
+
+func (DeletedAtStamp) DeleteClauses(f *schema.Field) []clause.Interface {
+	return []clause.Interface{DeletedAtStampDeleteClause{Field: f}}
+}
+
+func (DeletedAtStamp) CreateClauses(f *schema.Field) []clause.Interface {
+	return []clause.Interface{DeletedAtStampCreateClause{Field: f}}
+}
+
+type baseClause struct {
+	softDeletedMode string
+}
+
+func (baseClause) Name() string {
+	return ""
+}
+
+func (baseClause) Build(_ clause.Builder) {}
+
+func (baseClause) MergeClause(_ *clause.Clause) {}
+
+type DeletedatstampQueryclause struct {
+	baseClause
+
+	Field *schema.Field
+}
+
+func (qc DeletedatstampQueryclause) ModifyStatement(stmt *gorm.Statement) {
+	if _, ok := stmt.Clauses["soft_delete_enabled"]; !ok && !stmt.Statement.Unscoped {
+		if c, ok := stmt.Clauses["WHERE"]; ok {
+			if where, ok := c.Expression.(clause.Where); ok && len(where.Exprs) >= 1 {
+				for _, expr := range where.Exprs {
+					if orCond, ok := expr.(clause.OrConditions); ok && len(orCond.Exprs) == 1 {
+						where.Exprs = []clause.Expression{clause.And(where.Exprs...)}
+						c.Expression = where
+						stmt.Clauses["WHERE"] = c
+						break
+					}
+				}
+			}
+		}
+
+		stmt.AddClause(clause.Where{Exprs: []clause.Expression{
+			clause.Or(
+				clause.Eq{Column: clause.Column{Table: clause.CurrentTable, Name: qc.Field.DBName}, Value: 0},
+				clause.Eq{Column: clause.Column{Table: clause.CurrentTable, Name: qc.Field.DBName}, Value: nil},
+			),
+		}})
+		stmt.Clauses["soft_delete_enabled"] = clause.Clause{}
+	}
+}
+
+type DeletedAtStampUpdateClause struct {
+	baseClause
+
+	Field *schema.Field
+}
+
+func (qc DeletedAtStampUpdateClause) ModifyStatement(stmt *gorm.Statement) {
+	if stmt.SQL.Len() == 0 && !stmt.Statement.Unscoped {
+		DeletedatstampQueryclause(qc).ModifyStatement(stmt)
+	}
+}
+
+type DeletedAtStampDeleteClause struct {
+	baseClause
+
+	Field *schema.Field
+}
+
+// ModifyStatement .
+func (sd DeletedAtStampDeleteClause) ModifyStatement(stmt *gorm.Statement) {
+	if stmt.SQL.Len() == 0 && !stmt.Statement.Unscoped {
+		curTime := stmt.DB.NowFunc().UnixMilli()
+		stmt.AddClause(clause.Set{{Column: clause.Column{Name: sd.Field.DBName}, Value: curTime}})
+		stmt.SetColumn(sd.Field.DBName, curTime, true)
+
+		if stmt.Schema != nil {
+			_, queryValues := schema.GetIdentityFieldValuesMap(stmt.Context, stmt.ReflectValue, stmt.Schema.PrimaryFields)
+			column, values := schema.ToQueryValues(stmt.Table, stmt.Schema.PrimaryFieldDBNames, queryValues)
+
+			if len(values) > 0 {
+				stmt.AddClause(clause.Where{Exprs: []clause.Expression{clause.IN{Column: column, Values: values}}})
+			}
+
+			if stmt.ReflectValue.CanAddr() && stmt.Dest != stmt.Model && stmt.Model != nil {
+				_, queryValues = schema.GetIdentityFieldValuesMap(stmt.Context, reflect.ValueOf(stmt.Model), stmt.Schema.PrimaryFields)
+				column, values = schema.ToQueryValues(stmt.Table, stmt.Schema.PrimaryFieldDBNames, queryValues)
+
+				if len(values) > 0 {
+					stmt.AddClause(clause.Where{Exprs: []clause.Expression{clause.IN{Column: column, Values: values}}})
+				}
+			}
+		}
+
+		DeletedatstampQueryclause(sd).ModifyStatement(stmt)
+		stmt.AddClauseIfNotExists(clause.Update{})
+		stmt.Build(stmt.DB.Callback().Update().Clauses...)
+	}
+}
+
+type DeletedAtStampCreateClause struct {
+	baseClause
+
+	Field *schema.Field
+}
+
+func (c DeletedAtStampCreateClause) ModifyStatement(stmt *gorm.Statement) {
+	if stmt.SQL.Len() == 0 && !stmt.Statement.Unscoped {
+		stmt.SetColumn(c.Field.Name, sql.NullInt64{Int64: 0, Valid: true})
+	}
+}

--- a/providers/mysql/v2/plugins/fields/soft_delete_stamp_test.go
+++ b/providers/mysql/v2/plugins/fields/soft_delete_stamp_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fields_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/erda-project/erda-infra/providers/mysql/v2/plugins/fields"
+)
+
+type User2 struct {
+	ID        uint
+	Name      string
+	Age       uint
+	DeletedAt fields.DeletedAtStamp
+}
+
+func TestDeletedAtStamp(t *testing.T) {
+	dsn := filepath.Join(os.TempDir(), "gorm.db")
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect to database: %v", err)
+	}
+	defer os.Remove(dsn)
+	db = db.Debug()
+
+	user := User2{Name: "dspo", Age: 20}
+	t.Log("drop table")
+	if err = db.Migrator().DropTable(new(User2)); err != nil {
+		t.Fatalf("failed to drop table: %v", err)
+	}
+	t.Log("auto migrate")
+	if err = db.AutoMigrate(new(User2)); err != nil {
+		t.Fatalf("failed to auto migrate: %v", err)
+	}
+	t.Log("save user")
+	db.Save(&user)
+
+	var count int64
+	var age uint
+
+	t.Log("count")
+	if db.Model(&User2{}).Where("name = ?", user.Name).Count(&count).Error != nil || count != 1 {
+		t.Errorf("count soft deleted record, expects: %v, got: %v", 1, count)
+	}
+
+	t.Log("select")
+	if db.Model(&User2{}).Select("age").Where("name = ?", user.Name).Scan(&age).Error != nil || age != user.Age {
+		t.Errorf("age soft deleted record, expects: %v, got: %v", user.Age, age)
+	}
+
+	t.Log("delete")
+	if err := db.Delete(&user).Error; err != nil {
+		t.Fatalf("no error should be happen when soft delte user, but got: %v", err)
+	}
+
+	if user.DeletedAt.Int64 == 0 {
+		t.Errorf("user's deleted at shoud be zero, bug got: %v", user.DeletedAt)
+	}
+
+	t.Log("dry run delete")
+	sql := db.Session(&gorm.Session{DryRun: true}).Delete(&user).Statement.SQL.String()
+	if !regexp.MustCompile(`UPDATE .user2. SET .deleted_at.=.* WHERE .user2.\..id. = .* AND \(.user2.\..deleted_at. = \? OR .user2.\..deleted_at. IS NULL\)`).MatchString(sql) {
+		t.Fatalf("invalid sql generated, got %v", sql)
+	}
+
+	t.Log("first")
+	if db.First(&User2{}, "name = ?", user.Name).Error == nil {
+		t.Errorf("can not find a soft deleted record")
+	}
+
+	count = 0
+	t.Log("count")
+	if db.Model(&User2{}).Where("name = ?", user.Name).Count(&count).Error != nil || count != 0 {
+		t.Errorf("count soft deleted record, expects: %v, got: %v", 0, count)
+	}
+
+	age = 0
+	t.Log("select age")
+	if err := db.Model(&User2{}).Select("age").Where("name = ?", user.Name).Scan(&age).Error; err != nil || age != 0 {
+		t.Fatalf("age soft deleted record, expects: %v, got: %v, err: %v", 0, age, err)
+	}
+
+	t.Log("unscoped first")
+	if err := db.Unscoped().First(&User2{}, "name = ?", user.Name).Error; err != nil {
+		t.Errorf("should find soft deleted record with Unscoped, but got err: %v", err)
+	}
+
+	t.Log("unscoped delete")
+	db.Unscoped().Delete(&user)
+	t.Log("unscoped first")
+	if err := db.Unscoped().First(&User2{}, "name = ?", user.Name).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Errorf("can not permanently deleted record")
+	}
+}

--- a/providers/mysql/v2/plugins/fields/soft_delete_test.go
+++ b/providers/mysql/v2/plugins/fields/soft_delete_test.go
@@ -35,11 +35,12 @@ type User struct {
 }
 
 func TestSoftDelete(t *testing.T) {
-	DB, err := gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{})
-	DB = DB.Debug()
+	dsn := filepath.Join(os.TempDir(), "gorm.db")
+	DB, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	if err != nil {
 		t.Errorf("failed to connect database")
 	}
+	DB = DB.Debug()
 
 	user := User{Name: "jinzhu", Age: 20}
 	DB.Migrator().DropTable(&User{})
@@ -54,7 +55,7 @@ func TestSoftDelete(t *testing.T) {
 	}
 
 	if DB.Model(&User{}).Select("age").Where("name = ?", user.Name).Scan(&age).Error != nil || age != user.Age {
-		t.Errorf("Age soft deleted record, expects: %v, got: %v", 0, age)
+		t.Errorf("Age soft deleted record, expects: %v, got: %v", user.Age, age)
 	}
 
 	if err := DB.Delete(&user).Error; err != nil {
@@ -102,212 +103,4 @@ func TestSoftDelete(t *testing.T) {
 	if err := DB.Unscoped().First(&User{}, "name = ?", user.Name).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
 		t.Errorf("Can't find permanently deleted record")
 	}
-}
-
-type MilliUser struct {
-	ID        uint
-	Name      string
-	Age       uint
-	DeletedAt fields.DeletedAt `gorm:"softDelete:milli"`
-}
-
-func TestSoftDeleteMilliMode(t *testing.T) {
-	DB, err := gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{})
-	DB = DB.Debug()
-	if err != nil {
-		t.Errorf("failed to connect database")
-	}
-
-	user := MilliUser{Name: "jinzhu", Age: 20}
-	DB.Migrator().DropTable(&MilliUser{})
-	DB.AutoMigrate(&MilliUser{})
-	DB.Save(&user)
-
-	var count int64
-	var age uint
-
-	if DB.Model(&MilliUser{}).Where("name = ?", user.Name).Count(&count).Error != nil || count != 1 {
-		t.Errorf("Count soft deleted record, expects: %v, got: %v", 1, count)
-	}
-
-	if DB.Model(&MilliUser{}).Select("age").Where("name = ?", user.Name).Scan(&age).Error != nil || age != user.Age {
-		t.Errorf("Age soft deleted record, expects: %v, got: %v", 0, age)
-	}
-
-	if err := DB.Delete(&user).Error; err != nil {
-		t.Fatalf("No error should happen when soft delete user, but got %v", err)
-	}
-
-	if user.DeletedAt.Time.IsZero() {
-		t.Errorf("user's deleted at should not be zero, DeletedAt: %v", user.DeletedAt)
-	}
-
-	sql := DB.Session(&gorm.Session{DryRun: true}).Delete(&user).Statement.SQL.String()
-	if !regexp.MustCompile(`UPDATE .milli_users. SET .deleted_at.=.* WHERE .milli_users.\..id. = .* AND \(.milli_users.\..deleted_at. = \? OR .milli_users.\..deleted_at. IS NULL\)`).MatchString(sql) {
-		t.Fatalf("invalid sql generated, got %v", sql)
-	}
-
-	if DB.First(&MilliUser{}, "name = ?", user.Name).Error == nil {
-		t.Errorf("Can't find a soft deleted record")
-	}
-
-	count = 0
-	if DB.Model(&MilliUser{}).Where("name = ?", user.Name).Count(&count).Error != nil || count != 0 {
-		t.Errorf("Count soft deleted record, expects: %v, got: %v", 0, count)
-	}
-
-	age = 0
-	if err := DB.Model(&MilliUser{}).Select("age").Where("name = ?", user.Name).Scan(&age).Error; err != nil || age != 0 {
-		t.Fatalf("Age soft deleted record, expects: %v, got: %v, err %v", 0, age, err)
-	}
-
-	if err := DB.Unscoped().First(&MilliUser{}, "name = ?", user.Name).Error; err != nil {
-		t.Errorf("Should find soft deleted record with Unscoped, but got err %s", err)
-	}
-
-	count = 0
-	if DB.Unscoped().Model(&MilliUser{}).Where("name = ?", user.Name).Count(&count).Error != nil || count != 1 {
-		t.Errorf("Count soft deleted record, expects: %v, count: %v", 1, count)
-	}
-
-	age = 0
-	if DB.Unscoped().Model(&MilliUser{}).Select("age").Where("name = ?", user.Name).Scan(&age).Error != nil || age != user.Age {
-		t.Errorf("Age soft deleted record, expects: %v, got: %v", 0, age)
-	}
-
-	DB.Unscoped().Delete(&user)
-	if err := DB.Unscoped().First(&MilliUser{}, "name = ?", user.Name).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
-		t.Errorf("Can't find permanently deleted record")
-	}
-}
-
-type FlagUser struct {
-	ID    uint
-	Name  string
-	Age   uint
-	IsDel fields.DeletedAt `gorm:"softDelete:flag"`
-}
-
-func TestSoftDeleteFlagMode(t *testing.T) {
-	DB, err := gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{})
-	DB = DB.Debug()
-	if err != nil {
-		t.Errorf("failed to connect database")
-	}
-
-	user := FlagUser{Name: "jinzhu", Age: 20}
-	DB.Migrator().DropTable(&FlagUser{})
-	DB.AutoMigrate(&FlagUser{})
-	DB.Save(&user)
-
-	var count int64
-	var age uint
-
-	if DB.Model(&FlagUser{}).Where("name = ?", user.Name).Count(&count).Error != nil || count != 1 {
-		t.Errorf("Count soft deleted record, expects: %v, got: %v", 1, count)
-	}
-
-	if DB.Model(&FlagUser{}).Select("age").Where("name = ?", user.Name).Scan(&age).Error != nil || age != user.Age {
-		t.Errorf("Age soft deleted record, expects: %v, got: %v", 0, age)
-	}
-
-	if err := DB.Delete(&user).Error; err != nil {
-		t.Fatalf("No error should happen when soft delete user, but got %v", err)
-	}
-
-	if user.IsDel.Time.IsZero() {
-		t.Errorf("user's deleted at should not be zero, IsDel: %v", user.IsDel)
-	}
-
-	sql := DB.Session(&gorm.Session{DryRun: true}).Delete(&user).Statement.SQL.String()
-	if !regexp.MustCompile(`UPDATE .flag_users. SET .is_del.=.* WHERE .flag_users.\..id. = .* AND \(.flag_users.\..is_del. = \? OR .flag_users.\..is_del. IS NULL\)`).MatchString(sql) {
-		t.Fatalf("invalid sql generated, got %v", sql)
-	}
-
-	if DB.First(&FlagUser{}, "name = ?", user.Name).Error == nil {
-		t.Errorf("Can't find a soft deleted record")
-	}
-
-	count = 0
-	if DB.Model(&FlagUser{}).Where("name = ?", user.Name).Count(&count).Error != nil || count != 0 {
-		t.Errorf("Count soft deleted record, expects: %v, got: %v", 0, count)
-	}
-
-	age = 0
-	if err := DB.Model(&FlagUser{}).Select("age").Where("name = ?", user.Name).Scan(&age).Error; err != nil || age != 0 {
-		t.Fatalf("Age soft deleted record, expects: %v, got: %v, err %v", 0, age, err)
-	}
-
-	if err := DB.Unscoped().First(&FlagUser{}, "name = ?", user.Name).Error; err != nil {
-		t.Errorf("Should find soft deleted record with Unscoped, but got err %s", err)
-	}
-
-	count = 0
-	if DB.Unscoped().Model(&FlagUser{}).Where("name = ?", user.Name).Count(&count).Error != nil || count != 1 {
-		t.Errorf("Count soft deleted record, expects: %v, count: %v", 1, count)
-	}
-
-	age = 0
-	if DB.Unscoped().Model(&FlagUser{}).Select("age").Where("name = ?", user.Name).Scan(&age).Error != nil || age != user.Age {
-		t.Errorf("Age soft deleted record, expects: %v, got: %v", 0, age)
-	}
-
-	DB.Unscoped().Delete(&user)
-	if err := DB.Unscoped().First(&FlagUser{}, "name = ?", user.Name).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
-		t.Errorf("Can't find permanently deleted record")
-	}
-}
-
-type NullableDeletedAtUser struct {
-	ID        int64
-	Name      string
-	Age       uint
-	DeletedAt fields.DeletedAt `gorm:"default:null"`
-}
-
-func TestNullableDeletedAtUser(t *testing.T) {
-	DB, err := gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{})
-	DB = DB.Debug()
-	if err != nil {
-		t.Errorf("failed to connect database")
-	}
-
-	user := NullableDeletedAtUser{Name: "shyamin", Age: 25}
-	DB.Migrator().DropTable(&NullableDeletedAtUser{})
-	DB.AutoMigrate(&NullableDeletedAtUser{})
-	DB.Save(&user)
-
-	var count int64
-	var age uint
-
-	if DB.Model(&NullableDeletedAtUser{}).Where("name = ?", user.Name).Count(&count).Error != nil || count != 1 {
-		t.Errorf("Count soft deleted record, expects: %v, got: %v", 1, count)
-	}
-
-	if DB.Model(&NullableDeletedAtUser{}).Select("age").Where("name = ?", user.Name).Scan(&age).Error != nil || age != user.Age {
-		t.Errorf("Age soft deleted record, expects: %v, got: %v", 0, age)
-	}
-
-	if err := DB.Delete(&user).Error; err != nil {
-		t.Fatalf("No error should happen when soft delete user, but got %v", err)
-	}
-
-}
-
-func TestSoftDeleteCreateClause_ModifyStatement(t *testing.T) {
-	DB, err := gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{})
-	if err != nil {
-		t.Errorf("failed to connect database")
-	}
-	DB = DB.Debug()
-
-	user := User{Name: "dspo", Age: 20}
-	DB.Migrator().DropTable(&User{})
-	DB.AutoMigrate(&User{})
-	DB.Save(&user)
-	sql := DB.Session(&gorm.Session{DryRun: true}).Create(&user).Statement.SQL.String()
-	t.Log(sql)
-	sql = DB.Session(&gorm.Session{DryRun: true}).Delete(&user).Statement.SQL.String()
-	t.Log(sql)
-	DB.Delete(&user)
 }

--- a/providers/mysql/v2/tx.go
+++ b/providers/mysql/v2/tx.go
@@ -19,8 +19,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// InvalidTransactionError means the transaction is alread committed or roll backed
-var InvalidTransactionError = errors.New("invalid transaction, it is already committed or roll backed")
+// ErrInvalidTransaction means the transaction is alread committed or roll backed
+var ErrInvalidTransaction = errors.New("invalid transaction, it is already committed or roll backed")
 
 // TX contains the CRUS APIs
 type TX struct {
@@ -39,7 +39,7 @@ func NewTx(db *gorm.DB) *TX {
 // Create inserts a row
 func (tx *TX) Create(i interface{}) error {
 	if tx.inTx && !tx.valid {
-		return InvalidTransactionError
+		return ErrInvalidTransaction
 	}
 	tx.Error = tx.db.Create(i).Error
 	return tx.Error
@@ -48,7 +48,7 @@ func (tx *TX) Create(i interface{}) error {
 // CreateInBatches inserts multi rows
 func (tx *TX) CreateInBatches(i interface{}, size int) error {
 	if tx.inTx && !tx.valid {
-		return InvalidTransactionError
+		return ErrInvalidTransaction
 	}
 	tx.Error = tx.db.CreateInBatches(i, size).Error
 	return tx.Error
@@ -57,7 +57,7 @@ func (tx *TX) CreateInBatches(i interface{}, size int) error {
 // Delete deletes rows with conditions
 func (tx *TX) Delete(i interface{}, options ...Option) (int64, error) {
 	if tx.inTx && !tx.valid {
-		return 0, InvalidTransactionError
+		return 0, ErrInvalidTransaction
 	}
 	var db = tx.DB()
 	for _, opt := range options {
@@ -71,7 +71,7 @@ func (tx *TX) Delete(i interface{}, options ...Option) (int64, error) {
 // options is conditions.
 func (tx *TX) Updates(i, v interface{}, options ...Option) error {
 	if tx.inTx && !tx.valid {
-		return InvalidTransactionError
+		return ErrInvalidTransaction
 	}
 	var db = tx.DB()
 	for _, opt := range options {
@@ -84,7 +84,7 @@ func (tx *TX) Updates(i, v interface{}, options ...Option) error {
 // At least one SetColumn Option in the options.
 func (tx *TX) SetColumns(i interface{}, options ...Option) error {
 	if tx.inTx && !tx.valid {
-		return InvalidTransactionError
+		return ErrInvalidTransaction
 	}
 	var db = tx.DB()
 	db = db.Model(i)
@@ -135,7 +135,7 @@ func (tx *TX) Commit() error {
 		return errors.New("not in transaction")
 	}
 	if !tx.valid {
-		return InvalidTransactionError
+		return ErrInvalidTransaction
 	}
 	if tx.Error != nil {
 		return errors.Wrap(tx.Error, "can not commit with error")
@@ -151,7 +151,7 @@ func (tx *TX) Rollback() error {
 		return errors.New("not in transaction")
 	}
 	if !tx.valid {
-		return InvalidTransactionError
+		return ErrInvalidTransaction
 	}
 	tx.db.Rollback()
 	tx.valid = false

--- a/providers/mysql/v2/tx.go
+++ b/providers/mysql/v2/tx.go
@@ -1,0 +1,188 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"errors"
+
+	"gorm.io/gorm"
+)
+
+var q *TX
+
+var InvalidTransactionError = errors.New("invalid transaction, it is already committed or roll backed")
+
+type TX struct {
+	Error error
+
+	tx    *gorm.DB
+	inTx  bool
+	valid bool
+}
+
+func Init(db *gorm.DB) {
+	if q == nil {
+		q = &TX{
+			tx:    db,
+			valid: true,
+		}
+	}
+}
+
+func Q() *TX {
+	if q == nil || q.tx == nil {
+		panic("q is not init")
+	}
+	return &TX{
+		tx:    q.tx,
+		valid: true,
+	}
+}
+
+func Begin() *TX {
+	return &TX{
+		tx:    Q().DB().Begin(),
+		valid: true,
+		inTx:  true,
+	}
+}
+
+func (tx *TX) Create(i interface{}) error {
+	if tx.inTx && !tx.valid {
+		return InvalidTransactionError
+	}
+	tx.Error = tx.tx.Create(i).Error
+	return tx.Error
+}
+
+func (tx *TX) CreateInBatches(i interface{}, size int) error {
+	if tx.inTx && !tx.valid {
+		return InvalidTransactionError
+	}
+	tx.Error = tx.tx.CreateInBatches(i, size).Error
+	return tx.Error
+}
+
+func (tx *TX) Delete(i interface{}, options ...Option) error {
+	options = append(options, deleteOption{i: i})
+	db := options[0].With(tx.tx)
+	if tx.Error = db.Error; tx.Error != nil {
+		return tx.Error
+	}
+	if len(options) > 1 {
+		for _, opt := range options[1:] {
+			db = opt.With(db)
+			if tx.Error = db.Error; tx.Error != nil {
+				return tx.Error
+			}
+		}
+	}
+	return tx.Error
+}
+
+func (tx *TX) Updates(i, v interface{}, options ...Option) error {
+	options = append(options, updatesOption{i: i, v: v})
+	db := options[0].With(tx.tx)
+	if tx.Error = db.Error; tx.Error != nil {
+		return tx.Error
+	}
+	if len(options) > 1 {
+		for _, opt := range options[1:] {
+			db = opt.With(db)
+			if tx.Error = db.Error; tx.Error != nil {
+				return tx.Error
+			}
+		}
+	}
+	return tx.Error
+}
+
+func (tx *TX) List(i interface{}, options ...Option) (int64, error) {
+	var total int64
+	var list = listOption{i: i, total: &total}
+	var opts []Option
+	for _, opt := range options {
+		if paging, ok := opt.(pageOption); ok {
+			list.pageSize, list.pageNo = paging.pageSize, paging.pageNo
+			continue
+		}
+		opts = append(opts, opt)
+	}
+	opts = append(opts, list)
+	db := opts[0].With(tx.tx)
+	if db.Error != nil {
+		if errors.Is(db.Error, gorm.ErrRecordNotFound) {
+			return 0, nil
+		}
+		tx.Error = db.Error
+		return 0, tx.Error
+	}
+	if len(opts) == 1 {
+		return total, nil
+	}
+	for _, opt := range opts[1:] {
+		db = opt.With(db)
+		if db.Error != nil {
+			if errors.Is(db.Error, gorm.ErrRecordNotFound) {
+				return 0, nil
+			}
+			tx.Error = db.Error
+			return 0, tx.Error
+		}
+	}
+	return total, nil
+}
+
+func (tx *TX) Get(i interface{}, options ...Option) (bool, error) {
+	options = append(options, firstOption{i: i})
+	db := options[0].With(tx.tx)
+	if db.Error != nil {
+		if errors.Is(db.Error, gorm.ErrRecordNotFound) {
+			return false, nil
+		}
+		tx.Error = db.Error
+		return false, tx.Error
+	}
+	if len(options) == 1 {
+		return true, nil
+	}
+	for _, opt := range options[1:] {
+		db = opt.With(db)
+		if db.Error != nil {
+			if errors.Is(db.Error, gorm.ErrRecordNotFound) {
+				return false, nil
+			}
+			tx.Error = db.Error
+			return false, tx.Error
+		}
+	}
+	return true, nil
+}
+
+func (tx *TX) CommitOrRollback() {
+	if tx.inTx && !tx.valid {
+		return
+	}
+	if tx.Error == nil {
+		tx.tx.Commit()
+	} else {
+		tx.tx.Rollback()
+	}
+	tx.valid = false
+}
+
+func (tx *TX) DB() *gorm.DB {
+	return tx.tx
+}

--- a/providers/mysql/v2/tx_test.go
+++ b/providers/mysql/v2/tx_test.go
@@ -1,0 +1,514 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2_test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	v2 "github.com/erda-project/erda-infra/providers/mysql/v2"
+)
+
+var dsn = filepath.Join(os.TempDir(), "gorm.db")
+var tx *v2.TX
+
+type User struct {
+	Age  int64 `gorm:"type:BIGINT"`
+	Name string
+}
+
+func TestTX(t *testing.T) {
+	openDB(t)
+	defer closeDB()
+
+	if err := tx.DB().AutoMigrate(new(User)); err != nil {
+		t.Fatalf("failed to migrate user: %v", err)
+	}
+
+	var (
+		name = v2.Col("name")
+		age  = v2.Col("age")
+	)
+
+	var prepare = func(t *testing.T) {
+		var users []User
+		for i := 0; i < 10; i++ {
+			users = append(users, User{Age: int64(i), Name: "dspo-" + strconv.Itoa(i)})
+		}
+		// INSERT INTO `users` (`age`,`name`) VALUES (0,"dspo-0"),(1,"dspo-1"),(2,"dspo-2"),(3,"dspo-3"),(4,"dspo-4"),(5,"dspo-5"),(6,"dspo-6"),(7,"dspo-7"),(8,"dspo-8"),(9,"dspo-9")
+		if err := tx.CreateInBatches(users, len(users)); err != nil {
+			t.Fatal(err)
+		}
+		total, err := tx.List(new([]User))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != 10 {
+			t.Fatalf("expects total: %v, got: %v", 11, total)
+		}
+	}
+	var clear = func(t *testing.T) {
+		// DELETE FROM `users` WHERE 1=1
+		_, err := tx.Delete(new(User), v2.Where("1=1"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		total, err := tx.List(new([]User))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != 0 {
+			t.Fatalf("expects total: %v, got: %v", 0, total)
+		}
+	}
+
+	t.Run("TX.Create", func(t *testing.T) {
+		defer t.Run("clear", clear)
+
+		// INSERT INTO `users` (`age`,`name`) VALUES (10,"dspo-10")
+		if err := tx.Create(&User{Age: 10, Name: "dspo-10"}); err != nil {
+			t.Fatalf("failed to Create: %v", err)
+		}
+		var user User
+		// SELECT * FROM `users` WHERE age = 10 AND name = "dspo-10" ORDER BY `users`.`age` LIMIT 1
+		ok, err := tx.Get(&user, age.Is(10), name.Is("dspo-10"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			t.Fatal("not ok")
+		}
+	})
+
+	t.Run("TX.CreateInBatches", func(t *testing.T) {
+		prepare(t)
+		clear(t)
+	})
+
+	t.Run("TX.Delete", func(t *testing.T) {
+		prepare(t)
+		defer clear(t)
+
+		var users []User
+		for i := 20; i < 30; i++ {
+			users = append(users, User{Age: int64(i), Name: "six-" + strconv.Itoa(i)})
+		}
+		if err := tx.CreateInBatches(users, len(users)); err != nil {
+			t.Fatal(err)
+		}
+		total, err := tx.Delete(new(User), age.GreaterThan(30))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != 0 {
+			t.Fatalf("expects total: %v, got: %v", 0, total)
+		}
+
+		total, err = tx.Delete(new(User), name.Like("six-%"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != 10 {
+			t.Fatalf("expects total: %v, got: %v", 10, total)
+		}
+	})
+
+	t.Run("TX.Updates by map", func(t *testing.T) {
+		prepare(t)
+		defer clear(t)
+
+		var user User
+		var values = map[string]interface{}{
+			"name": "cmc-10",
+			"age":  int64(100),
+		}
+		if err := tx.Updates(&user, values, name.Is("dspo-10")); err != nil {
+			t.Fatal(err)
+		}
+		if user.Name != values["name"] {
+			t.Fatalf("expects user.Name: %v, got: %v", values["name"], user.Name)
+		}
+		if user.Age != values["age"].(int64) {
+			t.Fatalf("expects user.Age: %v, got: %v", values["age"], user.Age)
+		}
+	})
+
+	t.Run("TX.Updates by struct", func(t *testing.T) {
+		prepare(t)
+		defer clear(t)
+
+		var user User
+		var values = User{
+			Age:  0,
+			Name: "0",
+		}
+		if err := tx.Updates(&user, values, name.Is("cmc-10")); err != nil {
+			t.Fatal(err)
+		}
+		if user.Age != values.Age {
+			t.Fatalf("expects user.Age: %v, got: %v", values, user.Age)
+		}
+		if user.Name != values.Name {
+			t.Fatalf("expects user.Name: %v, got: %v", values.Name, user.Name)
+		}
+	})
+
+	t.Run("TX.SetColumns", func(t *testing.T) {
+		prepare(t)
+		defer clear(t)
+
+		var user User
+		var value = User{Name: "cmc-10", Age: 10}
+		if err := tx.SetColumns(&user, name.Is("0"), name.Set(value.Name), age.Set(value.Age)); err != nil {
+			t.Fatal(err)
+		}
+		if user.Name != value.Name {
+			t.Fatalf("expects user.Name: %v, got: %v", value.Name, user.Name)
+		}
+		if user.Age != value.Age {
+			t.Fatalf("expects user.Age: %v, got: %v", value.Age, user.Age)
+		}
+	})
+
+	t.Run("Where", func(t *testing.T) {
+		t.Log("ignore")
+	})
+
+	t.Run("Wheres", func(t *testing.T) {
+		prepare(t)
+		defer clear(t)
+
+		var user User
+		ok, err := tx.Get(&user, v2.Wheres(map[string]interface{}{"name": "dspo-1"}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			t.Fatalf("expects ok: %v, got: %v", true, ok)
+		}
+		if user.Name != "dspo-1" || user.Age != 1 {
+			t.Fatalf("expects user.Name: %v, user.Age: %v, got name: %v, age: %v",
+				"dspo-1", 1, user.Name, user.Age)
+		}
+	})
+
+	t.Run("TX.List", func(t *testing.T) {
+		prepare(t)
+		defer clear(t)
+
+		var users []User
+		total, err := tx.List(&users)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != 10 {
+			t.Fatalf("expects total: %v, got: %v", 11, total)
+		}
+		if len(users) != 10 {
+			t.Fatalf("expects length of users: %v, got: %v", 11, len(users))
+		}
+	})
+
+	t.Run("TX.List with conditions", func(t *testing.T) {
+		prepare(t)
+		defer clear(t)
+
+		var users []User
+		total, err := tx.List(&users, name.Like("dspo%"), age.GreaterThan(5))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != 4 {
+			t.Fatalf("expects total: %v, got: %v", 4, total)
+		}
+		if len(users) != 4 {
+			t.Fatalf("expects length of users: %v, got: %v", 4, len(users))
+		}
+	})
+
+	t.Run("TX.List order by DESC", func(t *testing.T) {
+		prepare(t)
+		defer clear(t)
+
+		var users []User
+		total, err := tx.List(&users, age.DESC())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != 10 {
+			t.Fatalf("expects total: %v, got: %v", 11, total)
+		}
+		if users[0].Age != 9 {
+			t.Fatalf("expects users[0].Age: %v, got: %v", 10, users[0].Age)
+		}
+	})
+
+	t.Run("TX.List order by ASC", func(t *testing.T) {
+		prepare(t)
+		defer clear(t)
+
+		var users []User
+		total, err := tx.List(&users, age.ASC())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != 10 {
+			t.Fatalf("expects total: %v, got: %v", 11, total)
+		}
+		if users[0].Age != 0 {
+			t.Fatalf("expects users[0].Age: %v, got: %v", 0, users[0].Age)
+		}
+	})
+
+	t.Run("TX.List by paging", func(t *testing.T) {
+		prepare(t)
+		defer clear(t)
+
+		var users []User
+		total, err := tx.List(&users, v2.Paging(5, 1))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != 10 {
+			t.Fatalf("expects total: %v, got: %v", 11, total)
+		}
+		if len(users) != 5 {
+			t.Fatalf("expects length of users: %v, got: %v", 5, len(users))
+		}
+
+		if total != 10 {
+			t.Fatalf("expects total: %v, got: %v", 11, total)
+		}
+		if len(users) != 5 {
+			t.Fatalf("expects length of users: %v, got: %v", 5, len(users))
+		}
+
+		// SELECT * FROM `users`
+		total, err = tx.List(&users, v2.Paging(-1, 0))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != 10 {
+			t.Fatalf("expects total: %v, got: %v", 10, total)
+		}
+	})
+
+	t.Run("TX.Get", func(t *testing.T) {
+		prepare(t)
+		defer clear(t)
+
+		var user User
+		ok, err := tx.Get(&user)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			t.Fatalf("expects ok: %v, got: %v", true, ok)
+		}
+	})
+
+	t.Run("Tx.Get with conditions", func(t *testing.T) {
+		prepare(t)
+		defer clear(t)
+
+		var user User
+		ok, err := tx.Get(&user, name.Is("dspo-2"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			t.Fatalf("expects ok: %v, got: %v", true, ok)
+		}
+
+		ok, err = tx.Get(&user, name.Is("xxx"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ok {
+			t.Fatalf("expects ok: %v, got: %v", false, ok)
+		}
+	})
+
+	t.Run("WhereColumn.Is", func(t *testing.T) {
+		t.Log("ignore")
+	})
+
+	t.Run("WhereColumn.In", func(t *testing.T) {
+		prepare(t)
+		defer clear(t)
+
+		var users []User
+		total, err := tx.List(&users, name.In([]interface{}{"dspo-1", "dspo-2", "six-1", "six-2"}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != 2 {
+			t.Fatalf("expects total: %v, got: %v", 2, total)
+		}
+		if len(users) != 2 {
+			t.Fatalf("expects length of users: %v, got: %v", 2, len(users))
+		}
+	})
+
+	t.Run("WhereColumn.InMap", func(t *testing.T) {
+		prepare(t)
+		defer clear(t)
+
+		var users []User
+		total, err := tx.List(&users, name.InMap(map[interface{}]struct{}{
+			"dspo-1": {},
+			"dspo-2": {},
+			"six-1":  {},
+			"six-2":  {},
+		}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != 2 {
+			t.Fatalf("expects total: %v, got: %v", 2, total)
+		}
+		if len(users) != 2 {
+			t.Fatalf("expects length of users: %v, got: %v", 2, len(users))
+		}
+	})
+
+	t.Run("WhereColumn.Like", func(t *testing.T) {
+		t.Log("ignore")
+	})
+
+	t.Run("WhereColumn.GreaterThan", func(t *testing.T) {
+		t.Log("ignore")
+	})
+
+	t.Run("WhereColumn.EqGreaterThan", func(t *testing.T) {
+		prepare(t)
+		defer clear(t)
+
+		var users []User
+		total, err := tx.List(&users, age.EqGreaterThan(5))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != 5 {
+			t.Fatalf("expects total: %v, got: %v", 5, total)
+		}
+	})
+
+	t.Run("WhereColumn.LessThan", func(t *testing.T) {
+		prepare(t)
+		defer clear(t)
+
+		var users []User
+		total, err := tx.List(&users, age.LessThan(5))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != 5 {
+			t.Fatalf("expects total: %v, got: %v", 5, total)
+		}
+	})
+
+	t.Run("WhereColumn.EqLessThan", func(t *testing.T) {
+		prepare(t)
+		defer clear(t)
+
+		var users []User
+		total, err := tx.List(&users, age.EqLessThan(5))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != 6 {
+			t.Fatalf("expects total: %v, got: %v", 6, total)
+		}
+	})
+
+	t.Run("OrderColumn.DESC", func(t *testing.T) {
+		t.Log("ignore")
+	})
+
+	t.Run("OrderColumn.ASC", func(t *testing.T) {
+		t.Log("ignore")
+	})
+
+	t.Run("SetColumn.Set", func(t *testing.T) {
+		t.Log("ignore")
+	})
+
+	t.Run("WhereValue.In", func(t *testing.T) {
+		prepare(t)
+		defer clear(t)
+
+		var users []User
+		total, err := tx.List(&users, v2.Value("dspo-1").In("name", "age"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != 1 {
+			t.Fatalf("expects total: %v, got: %v", 1, total)
+		}
+	})
+
+	t.Run("Paging", func(t *testing.T) {
+		t.Log("ignore")
+	})
+
+	t.Run("OrderBy", func(t *testing.T) {
+		prepare(t)
+		defer clear(t)
+
+		var users []User
+		total, err := tx.List(&users, v2.OrderBy("age", v2.DESC))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != 10 {
+			t.Fatalf("expect total: %v, got: %v", 10, total)
+		}
+		if users[0].Name != "dspo-9" || users[0].Age != 9 {
+			t.Fatalf("expects user[0].Name: %v, user[0].Age: %v, got name: %v, age: %v",
+				"dspo-0", 0, users[0].Name, users[0].Age)
+		}
+
+		_, err = tx.List(&users, v2.OrderBy("age", v2.ASC))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if users[0].Name != "dspo-0" || users[0].Age != 0 {
+			t.Fatalf("expects user[0].Name: %v, user[0].Age: %v, got name: %v, age: %v",
+				"dspo-0", 0, users[0].Name, users[0].Age)
+		}
+	})
+}
+
+func openDB(t *testing.T) {
+	if tx != nil {
+		return
+	}
+	closeDB()
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open %s: %v", dsn, err)
+	}
+	tx = v2.NewTx(db.Debug())
+}
+
+func closeDB() {
+	os.Remove(dsn)
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
- en:
    - add field type `DeletedAtStamp` to support BIGINT type soft deleted field
    - more APIs for gorm.v2 provider
- zh:
    - 增加 `DeletedAtStamp` 字段类型以支持使用 BIGINT 类型作为软删除字段
    - 为 gorm.v2 provider 添加更便捷的 APIs

```go
type User2 struct {
	ID        uint
	Name      string
	Age       uint
	DeletedAt fields.DeletedAtStamp
}

db.Model(&User2{}).Select("age").Where("name = ?", user.Name)
// SELECT `age` FROM `user2` WHERE name = "dspo" AND (`user2`.`deleted_at` = 0 OR `user2`.`deleted_at` IS NULL)

db.Delete(&user)
// UPDATE `user2` SET `deleted_at`=1656933047280 WHERE `user2`.`id` = 1 AND (`user2`.`deleted_at` = 0 OR `user2`.`deleted_at` IS NULL)

db.First(&User2{}, "name = ?", user.Name)
// SELECT * FROM `user2` WHERE name = "dspo" AND (`user2`.`deleted_at` = 0 OR `user2`.`deleted_at` IS NULL) ORDER BY `user2`.`id` LIMIT 1

db.Model(&User2{}).Where("name = ?", user.Name).Count(&count)
// SELECT count(*) FROM `user2` WHERE name = "dspo" AND (`user2`.`deleted_at` = 0 OR `user2`.`deleted_at` IS NULL)

db.Model(&User2{}).Select("age").Where("name = ?", user.Name)
// SELECT `age` FROM `user2` WHERE name = "dspo" AND (`user2`.`deleted_at` = 0 OR `user2`.`deleted_at` IS NULL)

db.Unscoped().First(&User2{}, "name = ?", user.Name)
// SELECT * FROM `user2` WHERE name = "dspo" ORDER BY `user2`.`id` LIMIT 1

db.Unscoped().Delete(&user)
// DELETE FROM `user2` WHERE `user2`.`id` = 1
```

#### Which issue(s) this PR fixes:
Fixes #

#### Specified Reviewers:
/assign @your-reviewer

