### PR TITLE
feat: record http-server error to log

### DIFF
--- a/providers/httpserver/server/server.go
+++ b/providers/httpserver/server/server.go
@@ -114,6 +114,7 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Execute chain
 	if err := h(c); err != nil {
+		c.Logger().Errorf("url method: %s, path: %s, matcherPath: %s, ip: %s, header: %v", c.Request().Method, c.Request().URL.Path, c.Path(), c.RealIP(), c.Request().Header)
 		s.e.HTTPErrorHandler(err, c)
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

record http-server error to log

before:
<img width="763" alt="image" src="https://user-images.githubusercontent.com/13919034/177941770-cdb30155-cd7b-4201-839d-56c8758f2be3.png">
after:
<img width="1591" alt="image" src="https://user-images.githubusercontent.com/13919034/177941939-97bb8a4c-2c70-4aa1-b44f-934b9563455e.png">


#### Which issue(s) this PR fixes:

[Related Erda Issue](https://erda.cloud/erda/dop/projects/387/issues/all?id=325031&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1321&type=TASK)

