### PR TITLE
chore: httpserver remove recover interceptor to avoid always statuscode 200

### DIFF
--- a/providers/httpserver/provider.go
+++ b/providers/httpserver/provider.go
@@ -57,7 +57,7 @@ type provider struct {
 func (p *provider) Init(ctx servicehub.Context) error {
 	p.server = server.New(p.Cfg.Reloadable, &dataBinder{}, &structValidator{validator: validator.New()})
 
-	p.server.Use(interceptors.Recover(p.Log).(func(echo.HandlerFunc) echo.HandlerFunc))
+	//p.server.Use(interceptors.Recover(p.Log).(func(echo.HandlerFunc) echo.HandlerFunc))
 	p.server.Use(interceptors.SimpleRecord(p.getInterceptorOption()))
 	p.server.Use(interceptors.CORS(p.Cfg.AllowCORS))
 	p.server.Use(interceptors.InjectRequestID())


### PR DESCRIPTION
#### What this PR does / why we need it:

httpserver remove recover interceptor to avoid always statuscode 200


#### Specified Reviewers:

/assign @chengjoey 

