### PR TITLE
feat: update gohub version to 1.0.8

### DIFF
--- a/tools/go.mod
+++ b/tools/go.mod
@@ -3,7 +3,7 @@ module github.com/erda-project/erda-infra/tools
 go 1.17
 
 require (
-	github.com/erda-project/erda-infra v1.0.7
+	github.com/erda-project/erda-infra v1.0.8
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.1.3
 	google.golang.org/genproto v0.0.0-20210820002220-43fce44e7af1

--- a/tools/gohub/cmd/version/version.go
+++ b/tools/gohub/cmd/version/version.go
@@ -27,7 +27,7 @@ func init() {
 }
 
 // Version .
-const Version = "1.0.7"
+const Version = "1.0.8"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",


### PR DESCRIPTION
#### What this PR does / why we need it:

update gohub version to 1.0.8