### PR TITLE
feat: add xorm closeState and sqlite's randomName

### DIFF
--- a/providers/mysqlxorm/sqlite3/examples/examples.yaml
+++ b/providers/mysqlxorm/sqlite3/examples/examples.yaml
@@ -1,5 +1,6 @@
 sqlite3-xorm:
   dbSourceName: "${SQLITE3_DB_SOURCE_NAME:test.sqlite3}"
   journalMode: "${SQLITE3_JOURNAL_MODE:memory}"
+  randomName: "true"
 
 example:

--- a/providers/mysqlxorm/sqlite3/examples/main.go
+++ b/providers/mysqlxorm/sqlite3/examples/main.go
@@ -30,6 +30,7 @@ type provider struct {
 
 func (p *provider) Init(ctx servicehub.Context) error {
 	fmt.Println(p.Sqlite3)
+	fmt.Println(p.Sqlite3.DB().DataSourceName())
 
 	// get journal_mode
 	results, _ := p.Sqlite3.DB().Query("PRAGMA journal_mode;")
@@ -48,6 +49,8 @@ func (p *provider) Run(ctx context.Context) error {
 		fmt.Printf("connect sqlite3 error : %s \n", err)
 		return err
 	}
+
+	p.Sqlite3.Close()
 	return nil
 }
 

--- a/providers/mysqlxorm/sqlite3/interface_test.go
+++ b/providers/mysqlxorm/sqlite3/interface_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,7 +27,7 @@ import (
 	"github.com/erda-project/erda-infra/providers/mysqlxorm"
 )
 
-const dbSourceName = "test1.sqlite3"
+const dbSourceName = "test1.db"
 
 type Server struct {
 	mysql mysqlxorm.Interface
@@ -67,13 +68,12 @@ func (s *Server) TestTx(err error, ops ...mysqlxorm.SessionOption) error {
 
 func TestNewSqlite3(t *testing.T) {
 	dbname := filepath.Join(os.TempDir(), dbSourceName)
-	defer func() {
-		os.Remove(dbname)
-	}()
 	engine, err := NewSqlite3(dbname)
 	if err != nil {
 		t.Fatalf("new sqlite3 err : %s", err)
 	}
+
+	defer engine.Close()
 
 	server := Server{
 		mysql: engine,
@@ -181,11 +181,42 @@ func TestJournalMode(t *testing.T) {
 		if err != nil {
 			t.Fatalf("new sqlite3 err : %s", err)
 		}
+		defer engine.Close()
 
 		// get journal in sqlite3
 		results, _ := engine.DB().Query("PRAGMA journal_mode;")
 		assert.Equal(t, string(w), string(results[0]["journal_mode"]))
-		os.Remove(dbname)
+		engine.Close()
 	}
 
+}
+
+func TestRandomName(t *testing.T) {
+	path := "/test/dir/sample.txt"
+	name1 := randomName(path)
+	name2 := randomName(path)
+
+	assert.True(t, strings.HasPrefix(name1, "/test/dir/sample-"), "Random name does not start with original name")
+
+	assert.Equal(t, filepath.Ext(name1), ".txt", "Random name does not have original extension")
+
+	assert.NotEqual(t, name1, name2, "Random name generator produced the same result twice")
+}
+
+func TestWithRandomName(t *testing.T) {
+	dbname := filepath.Join(os.TempDir(), dbSourceName)
+	engine, err := NewSqlite3(dbname, WithRandomName(false))
+	if err != nil {
+		panic(err)
+	}
+	defer engine.Close()
+	assert.Nil(t, err)
+	assert.Equal(t, dbname, engine.DataSourceName())
+	engine.Close()
+
+	engineRandom, err := NewSqlite3(dbname, WithRandomName(true))
+	assert.Nil(t, err)
+	assert.NotEqual(t, dbname, engineRandom, "Random name is not take effect")
+	assert.Equal(t, filepath.Ext(engineRandom.DataSourceName()), filepath.Ext(dbname), "Random names does not have original extension")
+	defer engineRandom.Close()
 }

--- a/providers/mysqlxorm/sqlite3/options.go
+++ b/providers/mysqlxorm/sqlite3/options.go
@@ -16,6 +16,7 @@ package sqlite3
 
 type Options struct {
 	JournalMode JournalMode
+	RandomName  bool
 }
 
 type OptionFunc func(options *Options)
@@ -34,5 +35,13 @@ const (
 func WithJournalMode(mode JournalMode) OptionFunc {
 	return func(o *Options) {
 		o.JournalMode = mode
+	}
+}
+
+// WithRandomName use to set the uuid in the given filename
+// such as `test.db => test-550e8400e29b41d4a716446655440000.db`
+func WithRandomName(isRandomName bool) OptionFunc {
+	return func(o *Options) {
+		o.RandomName = isRandomName
 	}
 }

--- a/providers/mysqlxorm/sqlite3/provider.go
+++ b/providers/mysqlxorm/sqlite3/provider.go
@@ -42,12 +42,16 @@ var _ servicehub.ProviderInitializer = (*provider)(nil)
 
 // Init .
 func (p *provider) Init(ctx servicehub.Context) error {
-	var path = p.Cfg.DbSourceName
+	var dbSourceName = p.Cfg.DbSourceName
+	var err error
 	if p.Cfg.RandomName {
-		path = randomName(p.Cfg.DbSourceName)
+		dbSourceName, err = randomName(p.Cfg.DbSourceName)
+		if err != nil {
+			return err
+		}
 	}
 
-	engine, err := xorm.NewEngine("sqlite3", path)
+	engine, err := xorm.NewEngine("sqlite3", dbSourceName)
 	if err != nil {
 		return fmt.Errorf("failed to connect to sqlite3 engine,err : %s", err)
 	}

--- a/providers/mysqlxorm/sqlite3/provider.go
+++ b/providers/mysqlxorm/sqlite3/provider.go
@@ -29,6 +29,7 @@ import (
 type config struct {
 	DbSourceName string `file:"dbSourceName" env:"SQLITE3_DB_SOURCE_NAME" default:"test.sqlite3"`
 	JournalMode  string `file:"journalMode" env:"SQLITE3_JOURNAL_MODE" default:""`
+	RandomName   bool   `file:"randomName" env:"SQLITE3_RANDOM_NAME" default:"false"`
 }
 
 type provider struct {
@@ -41,7 +42,12 @@ var _ servicehub.ProviderInitializer = (*provider)(nil)
 
 // Init .
 func (p *provider) Init(ctx servicehub.Context) error {
-	engine, err := xorm.NewEngine("sqlite3", p.Cfg.DbSourceName)
+	var path = p.Cfg.DbSourceName
+	if p.Cfg.RandomName {
+		path = randomName(p.Cfg.DbSourceName)
+	}
+
+	engine, err := xorm.NewEngine("sqlite3", path)
 	if err != nil {
 		return fmt.Errorf("failed to connect to sqlite3 engine,err : %s", err)
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
To add the DataSourceName and Close methods for xorm, and support SQLite3's random filename,

#### Which issue(s) this PR fixes:
Fixes #

#### Specified Reviewers:
/assign @sfwn 

#### CheckList
- [x] This pr has already passed build checks in erda
- [x] This pr has already passed by unit-test

