### PR TITLE
feat(logger): support Set KV multiple times as entry fields

### DIFF
--- a/base/logs/logrusx/log.go
+++ b/base/logs/logrusx/log.go
@@ -51,6 +51,12 @@ func (l *Logger) Sub(name string) logs.Logger {
 	return &Logger{name, l.Entry.WithField("module", name)}
 }
 
+// Set .
+func (l *Logger) Set(k, v string) logs.Logger {
+	l.Entry = l.Entry.WithField(k, v)
+	return l
+}
+
 // SetLevel .
 func (l *Logger) SetLevel(lvl string) error {
 	level, err := logrus.ParseLevel(lvl)

--- a/base/logs/logs.go
+++ b/base/logs/logs.go
@@ -21,6 +21,7 @@ import (
 // Logger .
 type Logger interface {
 	Sub(name string) Logger
+	Set(k, v string) Logger
 	Debug(args ...interface{})
 	Info(args ...interface{})
 	Warn(args ...interface{})


### PR DESCRIPTION
#### What this PR does / why we need it:

Logger support set multiple KVs for more log details.


